### PR TITLE
fix(ci): update claude-code-review to use correct action inputs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,31 +4,38 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: read
-
 jobs:
   review:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
     steps:
-      - uses: anthropics/claude-code-action@1fc90f3ed982521116d8ff6d85b948c9b12cae3e # v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          review_comment_prompt: |
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this PR following the guidance in CLAUDE.md.
             Focus on:
             - TypeScript best practices and type safety
             - MCP SDK usage patterns
             - API client error handling
             - Security (no hardcoded credentials, proper input validation)
-          allowed_tools: |
-            Bash(gh issue view *)
-            Bash(gh search issues *)
-            Bash(gh pr comment *)
-            Bash(gh pr diff *)
-            Bash(gh pr view *)
-            Bash(gh pr list *)
-          model: claude-opus-4-6
+            - Test coverage
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          claude_args: '--model claude-opus-4-6 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary
- Fix `review_comment_prompt`, `allowed_tools`, `model` → `prompt`, `claude_args`
- The action's valid inputs changed; old names were silently ignored, causing auth failures
- Match the working pattern from qurl-integrations repo
- Add `id-token: write` permission for OIDC

## Test plan
- [ ] Verify review job passes on this PR (it will use the old workflow since it's on main, but future PRs will use the fixed one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)