### PR TITLE
fix(client): correct Content-Type, limit check, metadata schema, and tool output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ QURL MCP Server is a TypeScript [Model Context Protocol](https://modelcontextpro
 ```
 qurl-mcp/
 ├── src/
-│   ├── index.ts           # Entry point, stdio transport, tool/resource registration
+│   ├── index.ts           # Entry point, env validation, stdio transport
+│   ├── server.ts          # MCP server factory, tool/resource registration
 │   ├── client.ts          # TypeScript QURL API client
 │   ├── tools/
 │   │   ├── create-qurl.ts

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "qurl-mcp": "./dist/index.js"
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -39,5 +40,8 @@
   },
   "files": [
     "dist/"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -58,7 +58,7 @@ describe("QURLClient", () => {
   });
 
   describe("request headers", () => {
-    it("sends Authorization bearer header and Content-Type", async () => {
+    it("sends Authorization bearer header on all requests", async () => {
       const mock = stubFetch({ data: {} });
 
       await client.getQuota();
@@ -66,12 +66,35 @@ describe("QURLClient", () => {
       expect(mock).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          headers: {
+          headers: expect.objectContaining({
             Authorization: "Bearer test-key",
-            "Content-Type": "application/json",
-          },
+          }),
         }),
       );
+    });
+
+    it("sends Content-Type only when request has a body", async () => {
+      const mock = stubFetch({ data: {} });
+
+      await client.createQURL({ target_url: "https://example.com" });
+
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+          }),
+        }),
+      );
+    });
+
+    it("omits Content-Type on GET requests", async () => {
+      const mock = stubFetch({ data: {} });
+
+      await client.getQuota();
+
+      const headers = (mock.mock.calls[0][1] as { headers: Record<string, string> }).headers;
+      expect(headers).not.toHaveProperty("Content-Type");
     });
   });
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -305,6 +305,15 @@ describe("QURLClient", () => {
       expect(calledUrl).toContain("cursor=cur_xyz");
     });
 
+    it("sends limit=0 as query param", async () => {
+      const mock = stubFetch({ data: [], meta: { has_more: false } });
+
+      await client.listQURLs({ limit: 0 });
+
+      const calledUrl = mock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("limit=0");
+    });
+
     it("sends only limit when cursor is not provided", async () => {
       const mock = stubFetch({ data: [], meta: { has_more: false } });
 

--- a/src/__tests__/resources/links.test.ts
+++ b/src/__tests__/resources/links.test.ts
@@ -37,6 +37,11 @@ describe("linksResource", () => {
       const resource = linksResource(makeMockClient());
       expect(resource.mimeType).toBe("application/json");
     });
+
+    it("has a description", () => {
+      const resource = linksResource(makeMockClient());
+      expect(resource.description).toBeTruthy();
+    });
   });
 
   describe("handler", () => {

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -16,7 +16,7 @@ describe("createServer", () => {
 
   async function connectServer() {
     const mockClient = makeMockClient();
-    server = createServer(mockClient);
+    server = createServer(mockClient, "0.1.0");
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);

--- a/src/__tests__/tools/create-qurl.test.ts
+++ b/src/__tests__/tools/create-qurl.test.ts
@@ -43,6 +43,15 @@ describe("createQurlTool", () => {
         expires_in: "24h",
         one_time_use: true,
         max_sessions: 5,
+        metadata: { env: "prod", team: "platform" },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts metadata as a record of unknown values", () => {
+      const result = createQurlSchema.safeParse({
+        target_url: "https://example.com",
+        metadata: { count: 42, nested: { a: 1 }, tags: ["x", "y"] },
       });
       expect(result.success).toBe(true);
     });
@@ -94,17 +103,14 @@ describe("createQurlTool", () => {
       expect(parsed.target_url).toBe("https://example.com/protected");
     });
 
-    it("formats response as pretty JSON", async () => {
+    it("formats response as compact JSON", async () => {
       const mockCreate = vi.fn().mockResolvedValue({ data: fixture });
       const client = makeMockClient({ createQURL: mockCreate });
       const tool = createQurlTool(client);
 
       const result = await tool.handler({ target_url: "https://example.com" });
-      const text = result.content[0].text;
 
-      // Pretty printed JSON has newlines
-      expect(text).toContain("\n");
-      expect(text).toBe(JSON.stringify(fixture, null, 2));
+      expect(result.content[0].text).toBe(JSON.stringify(fixture));
     });
 
     it("propagates client errors", async () => {
@@ -128,6 +134,7 @@ describe("createQurlTool", () => {
         expires_in: "1h",
         one_time_use: true,
         max_sessions: 3,
+        metadata: { env: "test" },
       };
       await tool.handler(input);
 

--- a/src/__tests__/tools/extend-qurl.test.ts
+++ b/src/__tests__/tools/extend-qurl.test.ts
@@ -80,7 +80,7 @@ describe("extendQurlTool", () => {
       const tool = extendQurlTool(client);
 
       const result = await tool.handler({ resource_id: "r_extend1", extend_by: "24h" });
-      expect(result.content[0].text).toBe(JSON.stringify(fixture, null, 2));
+      expect(result.content[0].text).toBe(JSON.stringify(fixture));
     });
 
     it("propagates client errors", async () => {

--- a/src/__tests__/tools/get-qurl.test.ts
+++ b/src/__tests__/tools/get-qurl.test.ts
@@ -73,7 +73,7 @@ describe("getQurlTool", () => {
       const text = result.content[0].text;
 
       // Should be the QURL object directly, not { data: ... }
-      expect(text).toBe(JSON.stringify(fixture, null, 2));
+      expect(text).toBe(JSON.stringify(fixture));
     });
 
     it("propagates client errors", async () => {

--- a/src/__tests__/tools/resolve-qurl.test.ts
+++ b/src/__tests__/tools/resolve-qurl.test.ts
@@ -82,7 +82,7 @@ describe("resolveQurlTool", () => {
       const tool = resolveQurlTool(client);
 
       const result = await tool.handler({ access_token: "at_token123" });
-      expect(result.content[0].text).toBe(JSON.stringify(sampleResolveOutput, null, 2));
+      expect(result.content[0].text).toBe(JSON.stringify(sampleResolveOutput));
     });
 
     it("propagates client errors", async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -104,7 +104,7 @@ export class QURLClient implements IQURLClient {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
     };
-    if (body) {
+    if (body !== undefined) {
       headers["Content-Type"] = "application/json";
     }
 
@@ -156,7 +156,7 @@ export class QURLClient implements IQURLClient {
   async listQURLs(input?: ListQURLsInput): Promise<ListQURLsOutput> {
     const params = new URLSearchParams();
     if (input?.limit !== undefined) params.set("limit", String(input.limit));
-    if (input?.cursor) params.set("cursor", input.cursor);
+    if (input?.cursor !== undefined) params.set("cursor", input.cursor);
     const query = params.toString();
     return this.request("GET", `/v1/qurls${query ? `?${query}` : ""}`);
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -103,8 +103,10 @@ export class QURLClient implements IQURLClient {
     const url = `${this.baseURL}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
-      "Content-Type": "application/json",
     };
+    if (body) {
+      headers["Content-Type"] = "application/json";
+    }
 
     const response = await fetch(url, {
       method,
@@ -153,7 +155,7 @@ export class QURLClient implements IQURLClient {
 
   async listQURLs(input?: ListQURLsInput): Promise<ListQURLsOutput> {
     const params = new URLSearchParams();
-    if (input?.limit) params.set("limit", String(input.limit));
+    if (input?.limit !== undefined) params.set("limit", String(input.limit));
     if (input?.cursor) params.set("cursor", input.cursor);
     const query = params.toString();
     return this.request("GET", `/v1/qurls${query ? `?${query}` : ""}`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -156,7 +156,7 @@ export class QURLClient implements IQURLClient {
   async listQURLs(input?: ListQURLsInput): Promise<ListQURLsOutput> {
     const params = new URLSearchParams();
     if (input?.limit !== undefined) params.set("limit", String(input.limit));
-    if (input?.cursor !== undefined) params.set("cursor", input.cursor);
+    if (input?.cursor) params.set("cursor", input.cursor);
     const query = params.toString();
     return this.request("GET", `/v1/qurls${query ? `?${query}` : ""}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { QURLClient } from "./client.js";
 import { createServer } from "./server.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
 
 const apiKey = process.env.QURL_API_KEY;
 if (!apiKey) {
@@ -13,7 +17,7 @@ if (!apiKey) {
 const baseURL = process.env.QURL_API_URL ?? "https://api.layerv.ai";
 
 const client = new QURLClient({ apiKey, baseURL });
-const server = createServer(client);
+const server = createServer(client, version);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,10 +9,10 @@ import { extendQurlTool, extendQurlSchema } from "./tools/extend-qurl.js";
 import { linksResource } from "./resources/links.js";
 import { usageResource } from "./resources/usage.js";
 
-export function createServer(client: IQURLClient): McpServer {
+export function createServer(client: IQURLClient, version: string): McpServer {
   const server = new McpServer({
     name: "qurl",
-    version: "0.1.0",
+    version,
   });
 
   // Register tools

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -7,6 +7,7 @@ export const createQurlSchema = z.object({
   expires_in: z.string().optional().describe('Duration string (e.g., "1h", "24h", "168h")'),
   one_time_use: z.boolean().optional().describe("Whether the link can only be used once"),
   max_sessions: z.number().int().positive().optional().describe("Maximum concurrent sessions"),
+  metadata: z.record(z.unknown()).optional().describe("Custom metadata key-value pairs"),
 });
 
 export function createQurlTool(client: IQURLClient) {
@@ -22,7 +23,7 @@ export function createQurlTool(client: IQURLClient) {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result.data, null, 2),
+            text: JSON.stringify(result.data),
           },
         ],
       };

--- a/src/tools/extend-qurl.ts
+++ b/src/tools/extend-qurl.ts
@@ -19,7 +19,7 @@ export function extendQurlTool(client: IQURLClient) {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result.data, null, 2),
+            text: JSON.stringify(result.data),
           },
         ],
       };

--- a/src/tools/get-qurl.ts
+++ b/src/tools/get-qurl.ts
@@ -16,7 +16,7 @@ export function getQurlTool(client: IQURLClient) {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result.data, null, 2),
+            text: JSON.stringify(result.data),
           },
         ],
       };

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -23,7 +23,8 @@ export function listQurlsTool(client: IQURLClient) {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result, null, 2),
+            // Full result (not .data) — includes meta.next_cursor for pagination
+            text: JSON.stringify(result),
           },
         ],
       };

--- a/src/tools/resolve-qurl.ts
+++ b/src/tools/resolve-qurl.ts
@@ -21,7 +21,7 @@ export function resolveQurlTool(client: IQURLClient) {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result.data, null, 2),
+            text: JSON.stringify(result.data),
           },
         ],
       };


### PR DESCRIPTION
## Summary

Code review of the MCP server source (never previously reviewed). Fixes all findings:

- **Content-Type on bodyless requests** — `client.ts` was sending `Content-Type: application/json` on GET/DELETE requests with no body. Some strict proxies/WAFs reject this. Now only set when body is present.
- **Truthy limit check** — `if (input?.limit)` silently dropped `limit: 0`. Changed to `!== undefined`. (Zod schema blocks 0 via `.min(1)` at the tool layer, but the client is a standalone class.)
- **Missing metadata in schema** — `CreateQURLInput` has an optional `metadata` field, but the Zod schema in `create-qurl.ts` didn't include it, causing Zod to silently strip metadata from agent input.
- **Pretty-printed tool output** — All 5 data-returning tools used `JSON.stringify(data, null, 2)` wasting LLM tokens. Resources already used compact JSON. Now consistent.
- **Hardcoded server version** — `server.ts` had `version: "0.1.0"` which will drift as Release Please bumps `package.json`. Now reads from `package.json` at startup.
- **Missing npm packaging fields** — Added `publishConfig.access: "public"` (scoped packages default to private) and `types` field for TypeScript consumers.
- **Stale CLAUDE.md** — Architecture section was missing `server.ts` and incorrectly described `index.ts` as handling registration.

## Test plan

- [x] All 113 tests pass (up from 109 — added 4 new tests)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)