### PR TITLE
feat(prompts): add MCP prompts for guided QURL workflows

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -31,6 +31,7 @@ jobs:
             tools
             client
             resources
+            prompts
             ci
             deps
           requireScope: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ QURL MCP Server is a TypeScript [Model Context Protocol](https://modelcontextpro
 qurl-mcp/
 ├── src/
 │   ├── index.ts           # Entry point, env validation, stdio transport
-│   ├── server.ts          # MCP server factory, tool/resource registration
+│   ├── server.ts          # MCP server factory, tool/resource/prompt registration
 │   ├── client.ts          # TypeScript QURL API client
 │   ├── tools/
 │   │   ├── create-qurl.ts
@@ -64,9 +64,13 @@ qurl-mcp/
 │   │   ├── get-qurl.ts
 │   │   ├── delete-qurl.ts
 │   │   └── extend-qurl.ts
-│   └── resources/
-│       ├── links.ts
-│       └── usage.ts
+│   ├── resources/
+│   │   ├── links.ts
+│   │   └── usage.ts
+│   └── prompts/
+│       ├── secure-a-service.ts
+│       ├── audit-links.ts
+│       └── rotate-access.ts
 ├── dist/                  # Compiled output (gitignored)
 ├── package.json
 └── tsconfig.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ feat(tools)!: rename resolve_qurl to resolve tool
 | `tools` | MCP tool implementations |
 | `client` | API client |
 | `resources` | MCP resources |
+| `prompts` | MCP prompts |
 | `ci` | GitHub Actions workflows |
 | `deps` | Dependencies |
 

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -17,7 +17,9 @@ export function makeMockClient(overrides: Partial<IQURLClient> = {}): IQURLClien
 
 export function getPromptText(result: GetPromptResult, index = 0): string {
   const content = result.messages[index].content;
-  return (content as { type: "text"; text: string }).text;
+  if (typeof content === "string") return content;
+  if (content.type !== "text") throw new Error(`Expected text content, got ${content.type}`);
+  return content.text;
 }
 
 export function sampleQURL(overrides: Partial<QURL> = {}): QURL {

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import type { IQURLClient, QURL } from "../client.js";
+import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 
 export function makeMockClient(overrides: Partial<IQURLClient> = {}): IQURLClient {
   return {
@@ -12,6 +13,11 @@ export function makeMockClient(overrides: Partial<IQURLClient> = {}): IQURLClien
     getQuota: vi.fn(),
     ...overrides,
   };
+}
+
+export function getPromptText(result: GetPromptResult, index = 0): string {
+  const content = result.messages[index].content;
+  return (content as { type: "text"; text: string }).text;
 }
 
 export function sampleQURL(overrides: Partial<QURL> = {}): QURL {

--- a/src/__tests__/prompts/audit-links.test.ts
+++ b/src/__tests__/prompts/audit-links.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { auditLinksPrompt } from "../../prompts/audit-links.js";
+import { getPromptText } from "../helpers.js";
 
 describe("auditLinksPrompt", () => {
   describe("metadata", () => {
@@ -26,49 +27,43 @@ describe("auditLinksPrompt", () => {
     it("instructs to use list_qurls tool", () => {
       const prompt = auditLinksPrompt();
       const result = prompt.handler();
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("list_qurls");
+      expect(getPromptText(result)).toContain("list_qurls");
     });
 
     it("includes expiration check instructions", () => {
       const prompt = auditLinksPrompt();
       const result = prompt.handler();
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("expiring");
+      expect(getPromptText(result)).toContain("expiring");
     });
 
     it("includes access count evaluation", () => {
       const prompt = auditLinksPrompt();
       const result = prompt.handler();
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("access_count");
+      expect(getPromptText(result)).toContain("access_count");
     });
 
     it("includes one_time_use check", () => {
       const prompt = auditLinksPrompt();
       const result = prompt.handler();
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("one_time_use");
+      expect(getPromptText(result)).toContain("one_time_use");
     });
 
     it("asks for a summary table", () => {
       const prompt = auditLinksPrompt();
       const result = prompt.handler();
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("table");
+      expect(getPromptText(result)).toContain("table");
     });
 
     it("recommends actions", () => {
       const prompt = auditLinksPrompt();
       const result = prompt.handler();
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("Recommend actions");
+      expect(getPromptText(result)).toContain("Recommend actions");
     });
   });
 });

--- a/src/__tests__/prompts/audit-links.test.ts
+++ b/src/__tests__/prompts/audit-links.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { auditLinksPrompt } from "../../prompts/audit-links.js";
+
+describe("auditLinksPrompt", () => {
+  describe("metadata", () => {
+    it("has correct name", () => {
+      const prompt = auditLinksPrompt();
+      expect(prompt.name).toBe("audit-links");
+    });
+
+    it("has a description", () => {
+      const prompt = auditLinksPrompt();
+      expect(prompt.description).toBeTruthy();
+    });
+  });
+
+  describe("handler", () => {
+    it("returns a single user message", () => {
+      const prompt = auditLinksPrompt();
+      const result = prompt.handler();
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe("user");
+    });
+
+    it("instructs to use list_qurls tool", () => {
+      const prompt = auditLinksPrompt();
+      const result = prompt.handler();
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("list_qurls");
+    });
+
+    it("includes expiration check instructions", () => {
+      const prompt = auditLinksPrompt();
+      const result = prompt.handler();
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("expiring");
+    });
+
+    it("includes access count evaluation", () => {
+      const prompt = auditLinksPrompt();
+      const result = prompt.handler();
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("access_count");
+    });
+
+    it("includes one_time_use check", () => {
+      const prompt = auditLinksPrompt();
+      const result = prompt.handler();
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("one_time_use");
+    });
+
+    it("asks for a summary table", () => {
+      const prompt = auditLinksPrompt();
+      const result = prompt.handler();
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("table");
+    });
+
+    it("recommends actions", () => {
+      const prompt = auditLinksPrompt();
+      const result = prompt.handler();
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("Recommend actions");
+    });
+  });
+});

--- a/src/__tests__/prompts/rotate-access.test.ts
+++ b/src/__tests__/prompts/rotate-access.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { rotateAccessPrompt } from "../../prompts/rotate-access.js";
+
+describe("rotateAccessPrompt", () => {
+  describe("metadata", () => {
+    it("has correct name", () => {
+      const prompt = rotateAccessPrompt();
+      expect(prompt.name).toBe("rotate-access");
+    });
+
+    it("has a description", () => {
+      const prompt = rotateAccessPrompt();
+      expect(prompt.description).toBeTruthy();
+    });
+
+    it("defines args schema with resource_id", () => {
+      const prompt = rotateAccessPrompt();
+      expect(prompt.args.resource_id).toBeDefined();
+    });
+  });
+
+  describe("handler", () => {
+    it("returns a single user message", () => {
+      const prompt = rotateAccessPrompt();
+      const result = prompt.handler({ resource_id: "r_test123" });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe("user");
+    });
+
+    it("includes resource_id in the message", () => {
+      const prompt = rotateAccessPrompt();
+      const result = prompt.handler({ resource_id: "r_abc456" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("r_abc456");
+    });
+
+    it("instructs to use get_qurl tool", () => {
+      const prompt = rotateAccessPrompt();
+      const result = prompt.handler({ resource_id: "r_test123" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("get_qurl");
+    });
+
+    it("instructs to use delete_qurl tool", () => {
+      const prompt = rotateAccessPrompt();
+      const result = prompt.handler({ resource_id: "r_test123" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("delete_qurl");
+    });
+
+    it("instructs to use create_qurl tool", () => {
+      const prompt = rotateAccessPrompt();
+      const result = prompt.handler({ resource_id: "r_test123" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("create_qurl");
+    });
+
+    it("defaults to 24h expiry when not specified", () => {
+      const prompt = rotateAccessPrompt();
+      const result = prompt.handler({ resource_id: "r_test123" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain('"24h"');
+    });
+
+    it("uses custom expiry when provided", () => {
+      const prompt = rotateAccessPrompt();
+      const result = prompt.handler({
+        resource_id: "r_test123",
+        extend_expiry: "168h",
+      });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain('"168h"');
+    });
+
+    it("includes step-by-step instructions", () => {
+      const prompt = rotateAccessPrompt();
+      const result = prompt.handler({ resource_id: "r_test123" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("1.");
+      expect(text).toContain("2.");
+      expect(text).toContain("3.");
+      expect(text).toContain("4.");
+      expect(text).toContain("5.");
+    });
+  });
+});

--- a/src/__tests__/prompts/rotate-access.test.ts
+++ b/src/__tests__/prompts/rotate-access.test.ts
@@ -68,7 +68,7 @@ describe("rotateAccessPrompt", () => {
       const prompt = rotateAccessPrompt();
       const result = prompt.handler({
         resource_id: "r_test123",
-        extend_expiry: "168h",
+        expires_in: "168h",
       });
 
       expect(getPromptText(result)).toContain('"168h"');

--- a/src/__tests__/prompts/rotate-access.test.ts
+++ b/src/__tests__/prompts/rotate-access.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { rotateAccessPrompt } from "../../prompts/rotate-access.js";
+import { getPromptText } from "../helpers.js";
 
 describe("rotateAccessPrompt", () => {
   describe("metadata", () => {
@@ -31,41 +32,36 @@ describe("rotateAccessPrompt", () => {
     it("includes resource_id in the message", () => {
       const prompt = rotateAccessPrompt();
       const result = prompt.handler({ resource_id: "r_abc456" });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("r_abc456");
+      expect(getPromptText(result)).toContain("r_abc456");
     });
 
     it("instructs to use get_qurl tool", () => {
       const prompt = rotateAccessPrompt();
       const result = prompt.handler({ resource_id: "r_test123" });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("get_qurl");
+      expect(getPromptText(result)).toContain("get_qurl");
     });
 
     it("instructs to use delete_qurl tool", () => {
       const prompt = rotateAccessPrompt();
       const result = prompt.handler({ resource_id: "r_test123" });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("delete_qurl");
+      expect(getPromptText(result)).toContain("delete_qurl");
     });
 
     it("instructs to use create_qurl tool", () => {
       const prompt = rotateAccessPrompt();
       const result = prompt.handler({ resource_id: "r_test123" });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("create_qurl");
+      expect(getPromptText(result)).toContain("create_qurl");
     });
 
     it("defaults to 24h expiry when not specified", () => {
       const prompt = rotateAccessPrompt();
       const result = prompt.handler({ resource_id: "r_test123" });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain('"24h"');
+      expect(getPromptText(result)).toContain('"24h"');
     });
 
     it("uses custom expiry when provided", () => {
@@ -74,15 +70,14 @@ describe("rotateAccessPrompt", () => {
         resource_id: "r_test123",
         extend_expiry: "168h",
       });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain('"168h"');
+      expect(getPromptText(result)).toContain('"168h"');
     });
 
     it("includes step-by-step instructions", () => {
       const prompt = rotateAccessPrompt();
       const result = prompt.handler({ resource_id: "r_test123" });
-      const text = (result.messages[0].content as { text: string }).text;
+      const text = getPromptText(result);
 
       expect(text).toContain("1.");
       expect(text).toContain("2.");

--- a/src/__tests__/prompts/secure-a-service.test.ts
+++ b/src/__tests__/prompts/secure-a-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { secureAServicePrompt } from "../../prompts/secure-a-service.js";
+import { getPromptText } from "../helpers.js";
 
 describe("secureAServicePrompt", () => {
   describe("metadata", () => {
@@ -31,9 +32,8 @@ describe("secureAServicePrompt", () => {
     it("includes target_url in the message", () => {
       const prompt = secureAServicePrompt();
       const result = prompt.handler({ target_url: "https://example.com/api" });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("https://example.com/api");
+      expect(getPromptText(result)).toContain("https://example.com/api");
     });
 
     it("includes description when provided", () => {
@@ -42,9 +42,8 @@ describe("secureAServicePrompt", () => {
         target_url: "https://example.com",
         description: "My API server",
       });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("My API server");
+      expect(getPromptText(result)).toContain("My API server");
     });
 
     it("includes expires_in when provided", () => {
@@ -53,9 +52,8 @@ describe("secureAServicePrompt", () => {
         target_url: "https://example.com",
         expires_in: "24h",
       });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("24h");
+      expect(getPromptText(result)).toContain("24h");
     });
 
     it("includes one_time_use when set to true", () => {
@@ -64,9 +62,8 @@ describe("secureAServicePrompt", () => {
         target_url: "https://example.com",
         one_time_use: "true",
       });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("one_time_use: true");
+      expect(getPromptText(result)).toContain("one_time_use: true");
     });
 
     it("includes max_sessions when provided", () => {
@@ -75,23 +72,21 @@ describe("secureAServicePrompt", () => {
         target_url: "https://example.com",
         max_sessions: "5",
       });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("max_sessions: 5");
+      expect(getPromptText(result)).toContain("max_sessions: 5");
     });
 
     it("instructs to use create_qurl tool", () => {
       const prompt = secureAServicePrompt();
       const result = prompt.handler({ target_url: "https://example.com" });
-      const text = (result.messages[0].content as { text: string }).text;
 
-      expect(text).toContain("create_qurl");
+      expect(getPromptText(result)).toContain("create_qurl");
     });
 
     it("works with only required args", () => {
       const prompt = secureAServicePrompt();
       const result = prompt.handler({ target_url: "https://example.com" });
-      const text = (result.messages[0].content as { text: string }).text;
+      const text = getPromptText(result);
 
       expect(text).toContain("target_url: https://example.com");
       expect(text).not.toContain("description:");

--- a/src/__tests__/prompts/secure-a-service.test.ts
+++ b/src/__tests__/prompts/secure-a-service.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { secureAServicePrompt } from "../../prompts/secure-a-service.js";
+
+describe("secureAServicePrompt", () => {
+  describe("metadata", () => {
+    it("has correct name", () => {
+      const prompt = secureAServicePrompt();
+      expect(prompt.name).toBe("secure-a-service");
+    });
+
+    it("has a description", () => {
+      const prompt = secureAServicePrompt();
+      expect(prompt.description).toBeTruthy();
+    });
+
+    it("defines args schema with target_url", () => {
+      const prompt = secureAServicePrompt();
+      expect(prompt.args.target_url).toBeDefined();
+    });
+  });
+
+  describe("handler", () => {
+    it("returns a single user message", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({ target_url: "https://example.com" });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe("user");
+    });
+
+    it("includes target_url in the message", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({ target_url: "https://example.com/api" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("https://example.com/api");
+    });
+
+    it("includes description when provided", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({
+        target_url: "https://example.com",
+        description: "My API server",
+      });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("My API server");
+    });
+
+    it("includes expires_in when provided", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({
+        target_url: "https://example.com",
+        expires_in: "24h",
+      });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("24h");
+    });
+
+    it("includes one_time_use when set to true", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({
+        target_url: "https://example.com",
+        one_time_use: "true",
+      });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("one_time_use: true");
+    });
+
+    it("includes max_sessions when provided", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({
+        target_url: "https://example.com",
+        max_sessions: "5",
+      });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("max_sessions: 5");
+    });
+
+    it("instructs to use create_qurl tool", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({ target_url: "https://example.com" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("create_qurl");
+    });
+
+    it("works with only required args", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({ target_url: "https://example.com" });
+      const text = (result.messages[0].content as { text: string }).text;
+
+      expect(text).toContain("target_url: https://example.com");
+      expect(text).not.toContain("description:");
+      expect(text).not.toContain("expires_in:");
+    });
+  });
+});

--- a/src/__tests__/prompts/secure-a-service.test.ts
+++ b/src/__tests__/prompts/secure-a-service.test.ts
@@ -66,6 +66,16 @@ describe("secureAServicePrompt", () => {
       expect(getPromptText(result)).toContain("one_time_use: true");
     });
 
+    it("includes one_time_use as false when set to false", () => {
+      const prompt = secureAServicePrompt();
+      const result = prompt.handler({
+        target_url: "https://example.com",
+        one_time_use: "false",
+      });
+
+      expect(getPromptText(result)).toContain("one_time_use: false");
+    });
+
     it("includes max_sessions when provided", () => {
       const prompt = secureAServicePrompt();
       const result = prompt.handler({

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -86,4 +86,30 @@ describe("createServer", () => {
       expect(uris).toEqual(["qurl://links", "qurl://usage"]);
     });
   });
+
+  describe("prompts", () => {
+    it("registers all 3 prompts", async () => {
+      const { client } = await connectServer();
+      const { prompts } = await client.listPrompts();
+
+      expect(prompts).toHaveLength(3);
+    });
+
+    it("registers prompts with correct names", async () => {
+      const { client } = await connectServer();
+      const { prompts } = await client.listPrompts();
+      const names = prompts.map((p) => p.name).sort();
+
+      expect(names).toEqual(["audit-links", "rotate-access", "secure-a-service"]);
+    });
+
+    it("each prompt has a description", async () => {
+      const { client } = await connectServer();
+      const { prompts } = await client.listPrompts();
+
+      for (const prompt of prompts) {
+        expect(prompt.description, `${prompt.name} missing description`).toBeTruthy();
+      }
+    });
+  });
 });

--- a/src/prompts/audit-links.ts
+++ b/src/prompts/audit-links.ts
@@ -1,0 +1,33 @@
+import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
+
+export function auditLinksPrompt() {
+  return {
+    name: "audit-links",
+    description:
+      "Review all active QURLs and identify expiring links, high-usage links, or potential issues.",
+    handler: (): GetPromptResult => {
+      return {
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: [
+                "Audit my active QURL links. Follow these steps:",
+                "",
+                "1. Use the list_qurls tool to fetch all active QURLs.",
+                "2. For each QURL, evaluate:",
+                "   - Is it expiring within the next 24 hours?",
+                "   - Does it have a high access_count relative to its max_sessions?",
+                "   - Is it a one_time_use link that has already been accessed?",
+                "   - Is it missing a description?",
+                "3. Summarize findings in a table with columns: resource_id, target_url, status, expires_at, access_count, and any flags.",
+                "4. Recommend actions for any issues found (extend, delete, or add description).",
+              ].join("\n"),
+            },
+          },
+        ],
+      };
+    },
+  };
+}

--- a/src/prompts/rotate-access.ts
+++ b/src/prompts/rotate-access.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
+
+export const rotateAccessArgs = {
+  resource_id: z.string().describe("The resource ID of the QURL to rotate"),
+  extend_expiry: z
+    .string()
+    .optional()
+    .describe('New expiration duration for the replacement QURL (e.g., "24h", "168h")'),
+};
+
+export function rotateAccessPrompt() {
+  return {
+    name: "rotate-access",
+    description:
+      "Rotate a QURL by revoking the existing link and creating a fresh one with the same target.",
+    args: rotateAccessArgs,
+    handler: (args: {
+      resource_id: string;
+      extend_expiry?: string;
+    }): GetPromptResult => {
+      const expiry = args.extend_expiry ?? "24h";
+
+      return {
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: [
+                `Rotate access for QURL ${args.resource_id}. Follow these steps:`,
+                "",
+                `1. Use the get_qurl tool to fetch the current details for resource_id "${args.resource_id}".`,
+                "2. Note the target_url, description, one_time_use, max_sessions, and metadata from the existing QURL.",
+                `3. Use the delete_qurl tool to revoke the old QURL "${args.resource_id}".`,
+                `4. Use the create_qurl tool to create a new QURL with the same target_url, description, one_time_use, max_sessions, and metadata, but with expires_in set to "${expiry}".`,
+                "5. Confirm the rotation was successful and provide the new qurl_link.",
+              ].join("\n"),
+            },
+          },
+        ],
+      };
+    },
+  };
+}

--- a/src/prompts/rotate-access.ts
+++ b/src/prompts/rotate-access.ts
@@ -9,16 +9,15 @@ export const rotateAccessArgs = {
     .describe('New expiration duration for the replacement QURL (e.g., "24h", "168h")'),
 };
 
+type RotateAccessInput = z.infer<z.ZodObject<typeof rotateAccessArgs>>;
+
 export function rotateAccessPrompt() {
   return {
     name: "rotate-access",
     description:
       "Rotate a QURL by revoking the existing link and creating a fresh one with the same target.",
     args: rotateAccessArgs,
-    handler: (args: {
-      resource_id: string;
-      extend_expiry?: string;
-    }): GetPromptResult => {
+    handler: (args: RotateAccessInput): GetPromptResult => {
       const expiry = args.extend_expiry ?? "24h";
 
       return {

--- a/src/prompts/rotate-access.ts
+++ b/src/prompts/rotate-access.ts
@@ -3,7 +3,7 @@ import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 
 export const rotateAccessArgs = {
   resource_id: z.string().describe("The resource ID of the QURL to rotate"),
-  extend_expiry: z
+  expires_in: z
     .string()
     .optional()
     .describe('New expiration duration for the replacement QURL (e.g., "24h", "168h")'),
@@ -18,7 +18,7 @@ export function rotateAccessPrompt() {
       "Rotate a QURL by revoking the existing link and creating a fresh one with the same target.",
     args: rotateAccessArgs,
     handler: (args: RotateAccessInput): GetPromptResult => {
-      const expiry = args.extend_expiry ?? "24h";
+      const expiry = args.expires_in ?? "24h";
 
       return {
         messages: [

--- a/src/prompts/secure-a-service.ts
+++ b/src/prompts/secure-a-service.ts
@@ -17,7 +17,7 @@ export const secureAServiceArgs = {
     .describe("Whether the link should be single-use"),
   max_sessions: z
     .string()
-    .regex(/^\d+$/, "Must be a positive integer")
+    .regex(/^[1-9]\d*$/, "Must be a positive integer")
     .optional()
     .describe("Maximum number of concurrent sessions (e.g., \"1\", \"5\")"),
 };

--- a/src/prompts/secure-a-service.ts
+++ b/src/prompts/secure-a-service.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
+
+export const secureAServiceArgs = {
+  target_url: z.string().describe("The URL of the service to protect with QURL"),
+  description: z
+    .string()
+    .optional()
+    .describe("Human-readable description of what this service is"),
+  expires_in: z
+    .string()
+    .optional()
+    .describe('How long the link should be valid (e.g., "1h", "24h", "168h")'),
+  one_time_use: z
+    .string()
+    .optional()
+    .describe('Whether the link should be single-use ("true" or "false")'),
+  max_sessions: z
+    .string()
+    .optional()
+    .describe("Maximum number of concurrent sessions (e.g., \"1\", \"5\")"),
+};
+
+export function secureAServicePrompt() {
+  return {
+    name: "secure-a-service",
+    description:
+      "Guide through creating a QURL to protect a service with appropriate security policies.",
+    args: secureAServiceArgs,
+    handler: (args: {
+      target_url: string;
+      description?: string;
+      expires_in?: string;
+      one_time_use?: string;
+      max_sessions?: string;
+    }): GetPromptResult => {
+      const parts = [
+        `Create a QURL to protect the following service: ${args.target_url}`,
+      ];
+
+      if (args.description) {
+        parts.push(`Description: ${args.description}`);
+      }
+
+      parts.push("");
+      parts.push("Use the create_qurl tool with the following parameters:");
+      parts.push(`- target_url: ${args.target_url}`);
+
+      if (args.description) {
+        parts.push(`- description: ${args.description}`);
+      }
+      if (args.expires_in) {
+        parts.push(`- expires_in: ${args.expires_in}`);
+      }
+      if (args.one_time_use) {
+        parts.push(`- one_time_use: ${args.one_time_use === "true"}`);
+      }
+      if (args.max_sessions) {
+        parts.push(`- max_sessions: ${args.max_sessions}`);
+      }
+
+      parts.push("");
+      parts.push(
+        "After creating the QURL, explain the returned qurl_link and how to share it securely. " +
+          "Note the expiration time and any access restrictions that were applied.",
+      );
+
+      return {
+        messages: [
+          {
+            role: "user",
+            content: { type: "text", text: parts.join("\n") },
+          },
+        ],
+      };
+    },
+  };
+}

--- a/src/prompts/secure-a-service.ts
+++ b/src/prompts/secure-a-service.ts
@@ -12,11 +12,12 @@ export const secureAServiceArgs = {
     .optional()
     .describe('How long the link should be valid (e.g., "1h", "24h", "168h")'),
   one_time_use: z
-    .string()
+    .enum(["true", "false"])
     .optional()
-    .describe('Whether the link should be single-use ("true" or "false")'),
+    .describe("Whether the link should be single-use"),
   max_sessions: z
     .string()
+    .regex(/^\d+$/, "Must be a positive integer")
     .optional()
     .describe("Maximum number of concurrent sessions (e.g., \"1\", \"5\")"),
 };

--- a/src/prompts/secure-a-service.ts
+++ b/src/prompts/secure-a-service.ts
@@ -21,19 +21,15 @@ export const secureAServiceArgs = {
     .describe("Maximum number of concurrent sessions (e.g., \"1\", \"5\")"),
 };
 
+type SecureAServiceInput = z.infer<z.ZodObject<typeof secureAServiceArgs>>;
+
 export function secureAServicePrompt() {
   return {
     name: "secure-a-service",
     description:
       "Guide through creating a QURL to protect a service with appropriate security policies.",
     args: secureAServiceArgs,
-    handler: (args: {
-      target_url: string;
-      description?: string;
-      expires_in?: string;
-      one_time_use?: string;
-      max_sessions?: string;
-    }): GetPromptResult => {
+    handler: (args: SecureAServiceInput): GetPromptResult => {
       const parts = [
         `Create a QURL to protect the following service: ${args.target_url}`,
       ];

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,13 +46,13 @@ export function createServer(client: IQURLClient, version: string): McpServer {
 
   // Register prompts
   const secure = secureAServicePrompt();
-  server.registerPrompt(secure.name, { description: secure.description, argsSchema: secure.args }, secure.handler);
+  server.prompt(secure.name, secure.description, secure.args, secure.handler);
 
   const audit = auditLinksPrompt();
-  server.registerPrompt(audit.name, { description: audit.description }, audit.handler);
+  server.prompt(audit.name, audit.description, audit.handler);
 
   const rotate = rotateAccessPrompt();
-  server.registerPrompt(rotate.name, { description: rotate.description, argsSchema: rotate.args }, rotate.handler);
+  server.prompt(rotate.name, rotate.description, rotate.args, rotate.handler);
 
   return server;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,9 @@ import { deleteQurlTool, deleteQurlSchema } from "./tools/delete-qurl.js";
 import { extendQurlTool, extendQurlSchema } from "./tools/extend-qurl.js";
 import { linksResource } from "./resources/links.js";
 import { usageResource } from "./resources/usage.js";
+import { secureAServicePrompt } from "./prompts/secure-a-service.js";
+import { auditLinksPrompt } from "./prompts/audit-links.js";
+import { rotateAccessPrompt } from "./prompts/rotate-access.js";
 
 export function createServer(client: IQURLClient, version: string): McpServer {
   const server = new McpServer({
@@ -40,6 +43,16 @@ export function createServer(client: IQURLClient, version: string): McpServer {
 
   const usage = usageResource(client);
   server.resource(usage.name, usage.uri, usage.handler);
+
+  // Register prompts
+  const secure = secureAServicePrompt();
+  server.registerPrompt(secure.name, { description: secure.description, argsSchema: secure.args }, secure.handler);
+
+  const audit = auditLinksPrompt();
+  server.registerPrompt(audit.name, { description: audit.description }, audit.handler);
+
+  const rotate = rotateAccessPrompt();
+  server.registerPrompt(rotate.name, { description: rotate.description, argsSchema: rotate.args }, rotate.handler);
 
   return server;
 }


### PR DESCRIPTION
## Summary
- Adds three MCP prompts (`secure-a-service`, `audit-links`, `rotate-access`) that guide AI agents through common QURL workflows
- Completes the MCP trifecta: tools, resources, and prompts are now all implemented
- Includes 34 new tests (148 total, up from 114) covering prompt metadata, handler output, and server integration

## Prompts

| Prompt | Args | Description |
|--------|------|-------------|
| `secure-a-service` | `target_url` (required), `description`, `expires_in`, `one_time_use`, `max_sessions` | Guides creating a QURL with appropriate security policies |
| `audit-links` | None | Reviews active QURLs for expiring links, high usage, and missing descriptions |
| `rotate-access` | `resource_id` (required), `extend_expiry` | Walks through revoking an old QURL and creating a fresh replacement |

## Test plan
- [x] `npm run build` — clean compilation
- [x] `npm run lint` — no lint errors
- [x] `npm test` — 148/148 tests pass
- [ ] Verify prompts appear via `client.listPrompts()` in MCP inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)