### PR TITLE
fix(deps): add repository URL for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   ],
   "author": "LayerV AI",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/layervai/qurl-mcp"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "zod": "^3.24.4"


### PR DESCRIPTION
## Summary
- Adds `repository` field to `package.json` pointing to `https://github.com/layervai/qurl-mcp`
- Required for `npm publish --provenance` to pass sigstore verification

## Test plan
- [ ] CI passes
- [ ] Re-run Release Please publish job succeeds