### PR TITLE
chore: enforce supply chain age gating

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=7
+ignore-scripts=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,9 @@
+# Supply-chain hardening: reject packages published <7 days ago.
+# Requires npm 11+ (Node 22+). Silently ignored on older versions.
+# CI enforces this (Node 22); local dev on older Node is not gated.
 min-release-age=7
+
+# Block arbitrary install/lifecycle scripts from dependencies.
+# Note: this also suppresses prepublishOnly during local `npm publish`.
+# CI runs `npm run build` explicitly before publish, so this is safe.
 ignore-scripts=true


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `min-release-age=7` to reject npm packages published less than 7 days ago
- Enables `ignore-scripts=true` to block arbitrary install scripts from packages

## Why
Newly published or hijacked packages are typically detected and removed within days. A 7-day quarantine ensures compromised packages never enter our dependency tree.

## Override for critical updates
```sh
npm install <pkg>@<version> --min-release-age=0
```

## Test plan
- [ ] `npm config get min-release-age --location=project` returns `7`
- [ ] `npm install` still resolves existing dependencies from lock file
- [ ] `npm install --min-release-age=0 <pkg>` bypasses the restriction