### PR TITLE
fix(ci): pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,16 +30,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@6c64db94d5b2e09d7e0948fb6bd3166cc6fffbc7 # v3.94.0
         with:
           extra_args: --only-verified


### PR DESCRIPTION
## Summary

Several workflows used mutable version tags instead of SHA pins. Tags can be retargeted — SHA pins prevent supply chain attacks on CI itself.

| Workflow | Action | Before | After |
|----------|--------|--------|-------|
| claude-code-review | actions/checkout | `@v6` | `@de0fac2e...` (v6.0.2) |
| claude-code-review | anthropics/claude-code-action | `@v1` | `@b47fd721...` (v1.0.93) |
| codeql | actions/checkout | `@v4` | `@de0fac2e...` (v6.0.2) |
| codeql | github/codeql-action/init | `@v4` | `@c10b8064...` (v4.35.1) |
| codeql | github/codeql-action/analyze | `@v4` | `@c10b8064...` (v4.35.1) |
| secrets-scan | trufflesecurity/trufflehog | `@main` | `@6c64db94...` (v3.94.0) |

The `@main` pin on TruffleHog was the worst case — it tracked HEAD of a third-party repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)