### PR TITLE
feat(deps)!: upgrade TypeScript 5.x to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@typescript-eslint/parser": "^8.32.1",
         "eslint": "^10.0.3",
         "prettier": "^3.5.3",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.2",
         "vitest": "^4.1.0"
       },
       "engines": {
@@ -3158,9 +3158,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/parser": "^8.32.1",
     "eslint": "^10.0.3",
     "prettier": "^3.5.3",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.2",
     "vitest": "^4.1.0"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

Upgrade TypeScript from 5.x to 6.0.2. This is a major version bump with a breaking change in how Node.js type definitions are resolved.

## Changes

| File | Change |
|------|--------|
| `package.json` | `typescript` ^5.8.3 → ^6.0.2 |
| `tsconfig.json` | Add `"types": ["node"]` to `compilerOptions` |
| `package-lock.json` | Regenerated |

## Why the tsconfig change

TypeScript 6.0 no longer implicitly includes `@types/node` in the compilation. Without the explicit `"types": ["node"]`, all Node.js globals (`process`, `Buffer`, `node:module`, etc.) fail to resolve with `TS2591`. The `@types/node` package was already a devDependency — it just needs to be explicitly referenced now.

## Verification

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 253 tests pass (16 test files)

## Context

Closes the gap left by the Dependabot PR (#47) which was closed because the major bump needed intentional adoption with the `tsconfig.json` fix.

Generated with [Claude Code](https://claude.com/claude-code)