### PR TITLE
feat(ci): add dependency age-gate scaffold (Phase 0)

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -1,0 +1,16 @@
+# Dependency Age Check (GitHub Actions pins)
+# Thin shim calling shared reusable workflow.
+name: Dependency Age Check (Actions)
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+
+jobs:
+  age-check:
+    uses: layervai/ops-routines/.github/workflows/age-check-actions.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -4,6 +4,7 @@ name: Dependency Age Check (Actions)
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - ".github/workflows/**"
       - ".github/actions/**"
@@ -11,6 +12,6 @@ on:
 
 jobs:
   age-check:
-    uses: layervai/ops-routines/.github/workflows/age-check-actions.yml@main
+    uses: layervai/ops-routines/.github/workflows/age-check-actions.yml@61d51059f8a3b2654694bada12a542b2be8ae17c # v0.1.0
     permissions:
       contents: read

--- a/.github/workflows/dependency-age-check-npm.yml
+++ b/.github/workflows/dependency-age-check-npm.yml
@@ -4,6 +4,7 @@ name: Dependency Age Check (npm)
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "**/package-lock.json"
       - "**/package.json"
@@ -11,7 +12,7 @@ on:
 
 jobs:
   age-check:
-    uses: layervai/ops-routines/.github/workflows/age-check-npm.yml@main
+    uses: layervai/ops-routines/.github/workflows/age-check-npm.yml@61d51059f8a3b2654694bada12a542b2be8ae17c # v0.1.0
     with:
       working_directory: .
     permissions:

--- a/.github/workflows/dependency-age-check-npm.yml
+++ b/.github/workflows/dependency-age-check-npm.yml
@@ -1,0 +1,18 @@
+# Dependency Age Check (npm)
+# Shim calling shared reusable workflow in ops-routines.
+name: Dependency Age Check (npm)
+
+on:
+  pull_request:
+    paths:
+      - "**/package-lock.json"
+      - "**/package.json"
+  workflow_dispatch:
+
+jobs:
+  age-check:
+    uses: layervai/ops-routines/.github/workflows/age-check-npm.yml@main
+    with:
+      working_directory: .
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

Phase 0 scaffold for replacing Dependabot with Claude Routines-driven dependency automation across the LayerV fleet. Orchestration code lives in [layervai/ops-routines](https://github.com/layervai/ops-routines).

## What this PR adds

Each `dependency-age-check-*.yml` is a thin shim calling a shared reusable workflow in `layervai/ops-routines`. The workflow rejects PRs that introduce dependencies published in the last 7 days (14 days for Docker base images) unless the PR carries the `age-check-bypass` label.

The `age-check-bypass` label is applied **only** by `layervai/ops-routines/.github/workflows/cve-verify.yml` after a deterministic verification chain (OSV + GHSA cross-reference, severity >= HIGH, publisher-continuity check). Claude never decides the bypass.

CODEOWNERS already present on `main`; this PR touches only the workflow shims.

## Why

The security review of the Dependabot-replacement plan required age-gate coverage on every ecosystem the routine will touch, before the pilot can start.

## Test plan

- [x] Commit GPG-signed
- [ ] CI green
- [ ] Reusable workflow resolves once the GitHub App is installed on this repo
- [ ] Age-check fires on a follow-up PR that modifies the relevant manifest

Related plan: see `layervai/ops-routines/runbooks/phase-0-checklist.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)