### PR TITLE
ci: migrate dep-age check to ops-routines v0.1.2

### DIFF
--- a/.github/workflows/dependency-age-check.yml
+++ b/.github/workflows/dependency-age-check.yml
@@ -36,6 +36,6 @@ jobs:
     # `contains(...)` is false, job always runs. That's the desired
     # behavior: manual runs shouldn't be bypassable via PR labels.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
-    uses: layervai/ops-routines/.github/workflows/age-check-npm.yml@a9ead86b8fd94edc31c1b3429f6edad67686d3f6 # v0.1.2
+    uses: layervai/ops-routines/.github/workflows/age-check-npm.yml@435d5be4e82fcf749b1689deb85dbcd5d29f9bac # v0.1.3
     permissions:
       contents: read

--- a/.github/workflows/dependency-age-check.yml
+++ b/.github/workflows/dependency-age-check.yml
@@ -1,0 +1,41 @@
+name: Dependency Age Check
+
+# Supply-chain guard: blocks PRs that introduce npm packages published
+# less than MIN_AGE_DAYS days ago. Thin shim delegating to the hardened
+# reusable workflow in layervai/ops-routines (see
+# https://github.com/layervai/ops-routines/blob/main/lib/age-check-npm.sh
+# for the implementation).
+#
+# Bypass: add the `age-check-bypass` label to the PR. Use only for
+# CVE-driven emergency updates (see ops-routines runbooks).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "package-lock.json"
+      - "pnpm-lock.yaml"
+      - "yarn.lock"
+  workflow_dispatch:
+
+# Cancel superseded runs on the same PR branch — each run makes
+# sequential registry calls with sleep gates; no reason to let two
+# race for an outdated diff.
+concurrency:
+  group: dep-age-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  age-check:
+    # Honor `age-check-bypass` at the shim level AND inside the
+    # reusable workflow (defense-in-depth). On `workflow_dispatch`
+    # `github.event.pull_request` is null — labels array is empty,
+    # `contains(...)` is false, job always runs. That's the desired
+    # behavior: manual runs shouldn't be bypassable via PR labels.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
+    uses: layervai/ops-routines/.github/workflows/age-check-npm.yml@a9ead86b8fd94edc31c1b3429f6edad67686d3f6 # v0.1.2
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

Adopts the shared reusable npm-dep-age workflow from [layervai/ops-routines v0.1.2](https://github.com/layervai/ops-routines/releases/tag/v0.1.2). Adds a ~30-line shim at `.github/workflows/dependency-age-check.yml`.

## Why this supersedes #52

The prior PR extracted the same dep-age logic into a per-repo script. That work surfaced the silent-pass bug class, 429-stderr-swallow, URL/markdown injection vectors, etc. **All of those discoveries are now in ops-routines v0.1.2** with a 106-test regression harness. Keeping a per-repo script means maintaining ~350 lines of security-critical bash duplicated across every fleet repo.

## What ops-routines v0.1.2 provides

- `is_valid_pkg_name` URL-injection defense (uppercase + `~` legacy allowed)
- `safe_for_md` markdown-injection defense on summary writes
- Split `git diff` from filter pipeline (silent-pass bug class fence)
- mktemp + trap + `--retry-all-errors` curl
- 404/410/429 distinct exit codes + stderr-routed 429 warning
- `:eyes: just past threshold` notice + `eligible after YYYY-MM-DD` error
- All-skipped guard (fail-closed on registry outage)

## Test plan

- [x] `actionlint` clean on the shim
- [ ] CI run exercises the shim against the current lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)