### PR TITLE
ci: add dep-age shims pointing at ops-routines-workflows v0.2.0

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -1,0 +1,44 @@
+# Dependency Age Check (Actions)
+# Thin shim calling shared reusable workflow.
+# Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-actions.yml
+name: Dependency Age Check (Actions)
+
+# Fires on every PR (no path filter) so the status check always reports.
+# This lets branch protection require it without the path-filtered-
+# required-check footgun. The reusable's script exits 0 quickly when
+# no relevant changes are in the diff.
+on:
+  pull_request:
+  workflow_dispatch:
+
+# Cancel superseded runs on the same PR branch.
+concurrency:
+  group: dep-age-actions-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  age-check:
+    # Honor `age-check-bypass` at the shim level AS WELL AS inside the
+    # reusable workflow. Defense-in-depth: if the reusable workflow
+    # implementation ever drops the label check (or the reusable ref
+    # is bumped to a version that doesn't respect it), the shim still
+    # skips consistently.
+    #
+    # On `workflow_dispatch`, `github.event.pull_request` is null — the
+    # labels array evaluates empty and `contains(...)` is false, so the
+    # job always runs. That's the desired behavior: manual runs
+    # shouldn't be bypassable via PR labels.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
+    # Note: `timeout-minutes` is intentionally NOT set here. Per GH
+    # docs (https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)
+    # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
+    # are valid on a job that calls a reusable workflow. The reusable
+    # workflow itself sets `timeout-minutes: 5` internally.
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
+    with:
+      min_age_days: 7
+    permissions:
+      contents: read

--- a/.github/workflows/dependency-age-check-npm.yml
+++ b/.github/workflows/dependency-age-check-npm.yml
@@ -1,0 +1,44 @@
+# Dependency Age Check (npm)
+# Thin shim calling shared reusable workflow.
+# Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-npm.yml
+name: Dependency Age Check (npm)
+
+# Fires on every PR (no path filter) so the status check always reports.
+# This lets branch protection require it without the path-filtered-
+# required-check footgun. The reusable's script exits 0 quickly when
+# no relevant changes are in the diff.
+on:
+  pull_request:
+  workflow_dispatch:
+
+# Cancel superseded runs on the same PR branch.
+concurrency:
+  group: dep-age-npm-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  age-check:
+    # Honor `age-check-bypass` at the shim level AS WELL AS inside the
+    # reusable workflow. Defense-in-depth: if the reusable workflow
+    # implementation ever drops the label check (or the reusable ref
+    # is bumped to a version that doesn't respect it), the shim still
+    # skips consistently.
+    #
+    # On `workflow_dispatch`, `github.event.pull_request` is null — the
+    # labels array evaluates empty and `contains(...)` is false, so the
+    # job always runs. That's the desired behavior: manual runs
+    # shouldn't be bypassable via PR labels.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'age-check-bypass') }}
+    # Note: `timeout-minutes` is intentionally NOT set here. Per GH
+    # docs (https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)
+    # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
+    # are valid on a job that calls a reusable workflow. The reusable
+    # workflow itself sets `timeout-minutes: 5` internally.
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-npm.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
+    with:
+      min_age_days: 7
+    permissions:
+      contents: read


### PR DESCRIPTION
Wires this repo into the LayerV supply-chain age gate using the modern self-contained reusable workflows in `layervai/ops-routines-workflows` v0.2.0. Public mirror, no cross-repo checkout, no App tokens, no secrets.

Supersedes older scaffold PRs (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)