### PR TITLE
docs: list update_qurl, mint_link, batch_create_qurls in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Replace `lv_live_xxx` with your actual API key. The key must have the appropriat
 | `list_qurls` | List active QURLs with optional pagination | `qurl:read` |
 | `get_qurl` | Get details of a specific QURL by resource ID | `qurl:read` |
 | `delete_qurl` | Revoke a QURL, immediately invalidating the link | `qurl:write` |
-| `extend_qurl` | Extend the expiration of an active QURL | `qurl:write` |
+| `extend_qurl` | Extend the expiration of an active QURL (alias for `update_qurl`) | `qurl:write` |
+| `update_qurl` | Update expiration, tags, or description on an active QURL | `qurl:write` |
+| `mint_link` | Mint a new access link for an existing protected resource | `qurl:write` |
+| `batch_create_qurls` | Create multiple QURLs in a single call | `qurl:write` |
 
 ## Available Resources
 


### PR DESCRIPTION
## Summary

Three tools that ship with the package — `update_qurl`, `mint_link`, `batch_create_qurls` — were already documented in `CLAUDE.md` and implemented under `src/tools/` but missing from the README's "Available Tools" table. Adds the rows.

## Why now

Doubles as the verification PR for [#57](https://github.com/layervai/qurl-mcp/pull/57) (claude-code-action v1.0.101 bump that fixes the Opus 4.7 `thinking.type.enabled` 400). The post-merge claude-review job for #57 itself ran against the PR's source branch's workflow file (which still pointed at the old broken pin), so the success signal we need is a *fresh* PR opened against the now-bumped main. If the claude-review job here posts a review comment instead of failing, the fleet-wide rollout is safe to merge.

## Test plan

- [x] `npm run lint` (no code changed but ran for completeness)
- [ ] `claude-review` job on this PR succeeds and posts a review comment to the PR