### PR TITLE
feat(ci): add fleet issue-template + priority-enforcement pattern

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,116 @@
+name: Bug Report
+description: Report a bug to help us improve. Do NOT use this for security vulnerabilities — report via GitHub Security Advisory.
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Security vulnerabilities: stop.** Report privately via [GitHub Security Advisory](https://github.com/layervai/qurl-mcp/security/advisories/new) or email `security@layerv.ai`. Do NOT open a public issue.
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: |
+        - **critical** — production outage potential, data loss risk, live-customer breakage
+        - **high** — significant user impact, blocker for other work, correctness bug in shipped feature
+        - **medium** — standard bug, non-urgent
+        - **low** — polish, minor fix, tech debt
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Include the MCP client (Claude Desktop, Cursor, etc.), the prompt or tool call, and any config that triggers the bug.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      # Keep this list aligned with the Scopes table in CLAUDE.md,
+      # EXCEPT for `other` — that's a reporter-UX escape hatch, not a
+      # valid commit scope. Adding a new scope? Update both places in
+      # the same PR. Not enforced at CI here; convention only.
+      description: Match one of the commit scopes in CLAUDE.md (or pick `other` for cross-cutting).
+      options:
+        - tools
+        - client
+        - resources
+        - prompts
+        - ci
+        - deps
+        - other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: Run `npm list @layerv/qurl-mcp` or check the installed version in your MCP client config.
+      placeholder: e.g. 0.3.x
+    validations:
+      required: true
+  - type: input
+    id: mcp_client
+    attributes:
+      label: MCP client
+      description: Which client is invoking the server?
+      placeholder: e.g. Claude Desktop 1.0, Cursor, custom
+    validations:
+      required: true
+  - type: input
+    id: node_version
+    attributes:
+      label: Node version
+      placeholder: e.g. 20.x (paste from `node --version`)
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: e.g. macOS 15, Ubuntu 24.04, Windows 11
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error output
+      description: |
+        Paste the MCP-client-side error, the server-side stdio transport error, and any stack trace.
+        **Redact before pasting:** bearer tokens, API keys (`lv_live_…` / `lv_test_…`), and customer identifiers.
+      # No `render:` — `render: shell` shell-highlights content, which
+      # miscolors TS stack traces and JSON-structured log lines.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, related issues, prior discussion, anything else worth knowing.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug to help us improve. Do NOT use this for security vulnerabilities — report via GitHub Security Advisory.
+description: Report a bug to help us improve. Do NOT use this for security vulnerabilities.
 title: "[BUG] "
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# `blank_issues_enabled: false` forces reporters through the bug-report
+# or feature-request forms, which carry a required Priority dropdown.
+# GitHub blocks blank-issue creation at the UI before any workflow
+# runs — the enforcement fail path is for issues that DO materialize
+# (e.g. API-filed) without a priority label. Better to prevent the
+# blank-issue state than to rely on surfacing it after creation.
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/layervai/qurl-mcp/security/advisories/new
+    about: Do NOT open a public bug report for security issues. Private disclosure via GitHub Security Advisory.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature Request
+description: Suggest an idea for this MCP server
+title: "[FEATURE] "
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      # Rubric wording is feature-shaped (describes ABSENCE, not
+      # failure) — distinct from bug_report.yml where critical
+      # describes harm from an existing defect. Keeping the four
+      # level names in lockstep across both forms; only the
+      # descriptions differ.
+      description: |
+        - **critical** — unblocks a committed delivery, closes a compliance/security gap, required for a live customer
+        - **high** — significant user value, blocks meaningful follow-on work
+        - **medium** — standard improvement, non-urgent
+        - **low** — polish, speculative, future
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem would this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Mockups, related issues, links to prior discussion.

--- a/.github/workflows/issue-priority.yml
+++ b/.github/workflows/issue-priority.yml
@@ -1,0 +1,53 @@
+# Issue Priority Enforcement
+# Thin shim calling shared reusable workflow.
+# Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/issue-priority.yml
+#
+# Matching form templates live in .github/ISSUE_TEMPLATE/ alongside this
+# file — GitHub does not allow cross-repo issue-template inheritance.
+name: Issue priority enforcement
+
+on:
+  issues:
+    types: [opened, reopened, edited, labeled, unlabeled]
+
+# Coalesce bursts on the same issue. Redundant with the reusable's own
+# concurrency group (same key shape), but mirrors the dep-age-check
+# shim convention so a future ref bump that accidentally drops the
+# reusable's concurrency doesn't silently remove all deduplication.
+#
+# `cancel-in-progress: false` — serialize rather than cancel. The
+# reusable uses `setLabels` (atomic PUT), so mid-flight cancellation
+# is safe today, but a future reusable that swaps labels non-
+# atomically (remove old → add new) would be vulnerable to a
+# cancelled run leaving an issue with no priority label, which would
+# then trip the enforcement fail path. Runs are bounded at 2 minutes;
+# queueing is cheap compared to the silent-drop failure mode.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-priority:
+    # Shim-level defense-in-depth against label-event recursion. The
+    # reusable applies priority labels, which emits `labeled` events
+    # that would re-trigger this workflow. GitHub's GITHUB_TOKEN-based
+    # identity suppression handles the common case, AND the reusable
+    # guards with `if: sender.type != 'Bot'`. This outer `if:` mirrors
+    # that guard at the caller so a future ref bump that silently
+    # drops the reusable's guard (or switches it to a PAT/App token,
+    # which bypasses GITHUB_TOKEN suppression) can't fully defeat
+    # loop prevention.
+    #
+    # Side effect: issues OPENED by `github-actions[bot]` are exempt
+    # from priority enforcement at creation time. Subsequent human
+    # `edited` / `labeled` events re-engage enforcement (not sticky).
+    # Other bots (dependabot, renovate, etc.) pass this guard but the
+    # reusable's own `sender.type != 'Bot'` check short-circuits them
+    # before setFailed — net effect is a near-instant no-op run.
+    if: ${{ github.actor != 'github-actions[bot]' }}
+    uses: layervai/ops-routines-workflows/.github/workflows/issue-priority.yml@5f1eb1a94cb7e222fb7a7b0610e3bd8293eeb58b # v0.3.0
+    permissions:
+      issues: write

--- a/.github/workflows/validate-issue-templates.yml
+++ b/.github/workflows/validate-issue-templates.yml
@@ -1,0 +1,38 @@
+# Issue-form schema validation
+# Thin shim calling shared reusable workflow.
+# Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/validate-issue-templates.yml
+#
+# The canonical check-jsonschema dispatch logic (forms vs config.yml)
+# lives in the reusable. A malformed form + `blank_issues_enabled:
+# false` silently hides issue creation until an external reporter
+# flags the breakage — this reusable fences that at PR time for every
+# repo in the fleet with identical version pins.
+name: Validate issue templates
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/validate-issue-templates.yml"
+  pull_request:
+    paths:
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/validate-issue-templates.yml"
+
+# Deliberately NO caller-side concurrency block. The reusable's
+# concurrency group evaluates `${{ github.workflow }}-…` against the
+# CALLER'S workflow name at runtime — a caller-side block using the
+# same key would collide with itself and fail the run at startup
+# before any job materializes (hit this in layervai/nhp#1307). The
+# issue-priority.yml reusable uses a literal prefix, which is why
+# a caller-side concurrency block works there. Tracked for fix at
+# the reusable side as layervai/ops-routines#39.
+# The reusable handles deduplication itself.
+
+permissions:
+  contents: read
+
+jobs:
+  validate-templates:
+    uses: layervai/ops-routines-workflows/.github/workflows/validate-issue-templates.yml@39fcb54fc36ea7b6032e138bd8b57647f2bb32f0 # v0.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,12 @@ feat(tools)!: rename resolve_qurl to resolve tool
 | `ci` | GitHub Actions workflows |
 | `deps` | Dependencies |
 
+> Keep this table aligned with the Component dropdown in
+> `.github/ISSUE_TEMPLATE/bug_report.yml`. Convention only (not CI-
+> enforced in this repo); add a new scope to both places in the same
+> PR. The dropdown's `other` option is a reporter-UX escape hatch —
+> do NOT add it here (it's not a valid commit scope).
+
 ## API Spec Maintenance
 
 The repository includes an API spec drift detection system:


### PR DESCRIPTION
## Summary

Introduces the fleet's structured issue-forms + reusable-workflow shim pattern to `qurl-mcp`. No existing `.md` templates to replace — this is the first structured issue intake for this repo.

## Business value

- **MCP-client-aware triage.** Bugs in an MCP server depend on the invoking client (Claude Desktop, Cursor, custom). Required MCP client + Component + Priority dropdowns give triage the three axes needed without back-and-forth.
- **Fleet consistency** with the rest of the org.
- **Fewer silent breakages.** `validate-issue-templates.yml` catches schema-broken forms at PR time.

## Per-repo adaptations

- **Component dropdown** matches CLAUDE.md's Scopes table: `tools / client / resources / prompts / ci / deps` + `other`.
- **New required MCP client input** — a server bug needs to name the client that surfaced it.
- **Reproduction hint** explicitly asks for the MCP client + prompt/tool call that triggered the bug (stdio transport issues often client-specific).
- **Logs hint** covers both client-side error reporting and server-side stdio transport output, with `lv_live_*` / `lv_test_*` redaction.
- **No Discussions link** (not enabled).
- **No SECURITY.md in this repo** — the GHSA URL on `config.yml` and `bug_report.yml` still resolves (GitHub provides the advisory surface even without a policy file).

## What changed

- `.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml`, `config.yml` — new files.
- `.github/workflows/issue-priority.yml` → `ops-routines-workflows@v0.3.0`.
- `.github/workflows/validate-issue-templates.yml` → `ops-routines-workflows@v0.4.0`. **No caller-side concurrency block** — `layervai/ops-routines#39`.
- `CLAUDE.md`: reciprocal lockstep note on the Component dropdown.

Priority labels + `bug` + `enhancement` already exist on this repo.

## Test plan

- [ ] `validate-issue-templates.yml` runs green on this PR
- [x] `check-jsonschema` + `actionlint` pass locally
- [ ] Post-merge: file a test issue, confirm Priority + Component + MCP client are required and `priority: *` auto-applies

## Fleet rollout

Seventh of ~8 active repos. Wave 2 complete after this: qurl-reverse-tunnel-server (#73), qurl-reverse-tunnel-client (#81), qurl-mcp. Final wave 3 will cover the remaining active repos.