### PR TITLE
docs: rebrand QURL → qURL across user-facing surfaces

### DIFF
--- a/.github/workflows/api-spec-check.yml
+++ b/.github/workflows/api-spec-check.yml
@@ -102,7 +102,7 @@ jobs:
           cat > /tmp/issue-body.md <<'BODY_EOF'
           ## API Spec Drift Detected
 
-          The QURL API OpenAPI specification has changed since the last snapshot.
+          The qURL API OpenAPI specification has changed since the last snapshot.
           BODY_EOF
 
           # Append dynamic content safely (no shell expansion)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           esac
 
           # Overall status: fail if either lint or test failed
-          HEADER="QURL MCP Build"
+          HEADER="qURL MCP Build"
           if [[ "$TEST_RESULT" == "success" && "$LINT_RESULT" == "success" ]]; then
             COLOR="#36a64f"; EMOJI=":white_check_mark:"; STATUS_TEXT="successful"
           elif [[ "$TEST_RESULT" == "failure" || "$LINT_RESULT" == "failure" ]]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Follow this process for all code changes:
 
 ## Project Overview
 
-QURL MCP Server is a TypeScript [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes QURL operations as tools for AI agents. It uses stdio transport and communicates with the QURL API.
+qURL MCP Server is a TypeScript [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes qURL operations as tools for AI agents. It uses stdio transport and communicates with the qURL API.
 
 ## Architecture
 
@@ -56,7 +56,7 @@ qurl-mcp/
 ├── src/
 │   ├── index.ts           # Entry point, env validation, stdio transport
 │   ├── server.ts          # MCP server factory, tool/resource/prompt registration
-│   ├── client.ts          # TypeScript QURL API client
+│   ├── client.ts          # TypeScript qURL API client
 │   ├── tools/
 │   │   ├── _shared.ts       # resourceIdSchema, zodErrorToToolResult
 │   │   ├── create-qurl.ts
@@ -107,7 +107,7 @@ npm run format
 | Variable | Required | Description | Default |
 |----------|----------|-------------|---------|
 | `QURL_API_KEY` | Yes | API key with `qurl:read`, `qurl:write`, and/or `qurl:resolve` scopes | — |
-| `QURL_API_URL` | No | QURL API base URL | `https://api.layerv.ai` |
+| `QURL_API_URL` | No | qURL API base URL | `https://api.layerv.ai` |
 
 ## MCP Usage
 
@@ -129,13 +129,13 @@ npm run format
 |------|---------------|-------------|
 | `create_qurl` | `qurl:write` | Create a protected link |
 | `resolve_qurl` | `qurl:resolve` | Resolve token + open firewall |
-| `list_qurls` | `qurl:read` | List QURLs with filtering |
-| `get_qurl` | `qurl:read` | Get QURL details |
-| `delete_qurl` | `qurl:write` | Revoke a QURL |
+| `list_qurls` | `qurl:read` | List qURLs with filtering |
+| `get_qurl` | `qurl:read` | Get qURL details |
+| `delete_qurl` | `qurl:write` | Revoke a qURL |
 | `extend_qurl` | `qurl:write` | Extend expiration (shorthand alias for `update_qurl`) |
 | `update_qurl` | `qurl:write` | Update expiration, tags, description |
 | `mint_link` | `qurl:write` | Mint a new access link for an existing resource |
-| `batch_create_qurls` | `qurl:write` | Create multiple QURLs at once |
+| `batch_create_qurls` | `qurl:write` | Create multiple qURLs at once |
 
 ## Commit Convention (Release Please)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![npm version](https://img.shields.io/npm/v/@layerv/qurl-mcp.svg)](https://www.npmjs.com/package/@layerv/qurl-mcp)
 
-MCP server for qURL secure link management.
+MCP server for qURL™ secure link management.
+
+> **Quantum URL (qURL)** · The internet has a hidden layer. This is how you enter.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![npm version](https://img.shields.io/npm/v/@layerv/qurl-mcp.svg)](https://www.npmjs.com/package/@layerv/qurl-mcp)
 
-MCP server for QURL secure link management.
+MCP server for qURL secure link management.
 
 ## What it does
 
-QURL MCP Server is a [Model Context Protocol](https://modelcontextprotocol.io/) server that lets AI agents (Claude, GPT, Cursor, etc.) create, resolve, list, and manage QURL secure links natively. It connects to the QURL API over stdio transport, so any MCP-compatible client can use it without custom integration code.
+qURL MCP Server is a [Model Context Protocol](https://modelcontextprotocol.io/) server that lets AI agents (Claude, GPT, Cursor, etc.) create, resolve, list, and manage qURL secure links natively. It connects to the qURL API over stdio transport, so any MCP-compatible client can use it without custom integration code.
 
 ## Quick Start
 
@@ -32,27 +32,27 @@ Replace `lv_live_xxx` with your actual API key. The key must have the appropriat
 |------|-------------|----------------|
 | `create_qurl` | Create a secure, policy-bound link to a protected resource | `qurl:write` |
 | `resolve_qurl` | Resolve an access token to get the target URL and open firewall access | `qurl:resolve` |
-| `list_qurls` | List active QURLs with optional pagination | `qurl:read` |
-| `get_qurl` | Get details of a specific QURL by resource ID | `qurl:read` |
-| `delete_qurl` | Revoke a QURL, immediately invalidating the link | `qurl:write` |
-| `extend_qurl` | Extend the expiration of an active QURL (alias for `update_qurl`) | `qurl:write` |
-| `update_qurl` | Update expiration, tags, or description on an active QURL | `qurl:write` |
+| `list_qurls` | List active qURLs with optional pagination | `qurl:read` |
+| `get_qurl` | Get details of a specific qURL by resource ID | `qurl:read` |
+| `delete_qurl` | Revoke a qURL, immediately invalidating the link | `qurl:write` |
+| `extend_qurl` | Extend the expiration of an active qURL (alias for `update_qurl`) | `qurl:write` |
+| `update_qurl` | Update expiration, tags, or description on an active qURL | `qurl:write` |
 | `mint_link` | Mint a new access link for an existing protected resource | `qurl:write` |
-| `batch_create_qurls` | Create multiple QURLs in a single call | `qurl:write` |
+| `batch_create_qurls` | Create multiple qURLs in a single call | `qurl:write` |
 
 ## Available Resources
 
 | URI | Name | Description |
 |-----|------|-------------|
-| `qurl://links` | Active QURL Links | List of all active QURL links |
-| `qurl://usage` | QURL Usage & Quota | Current quota and usage information |
+| `qurl://links` | Active qURL Links | List of all active qURL links |
+| `qurl://usage` | qURL Usage & Quota | Current quota and usage information |
 
 ## Configuration
 
 | Environment Variable | Required | Description | Default |
 |---------------------|----------|-------------|---------|
 | `QURL_API_KEY` | Yes | API key with appropriate scopes (`qurl:read`, `qurl:write`, `qurl:resolve`) | -- |
-| `QURL_API_URL` | No | QURL API base URL | `https://api.layerv.ai` |
+| `QURL_API_URL` | No | qURL API base URL | `https://api.layerv.ai` |
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@layerv/qurl-mcp",
   "version": "0.1.2",
-  "description": "MCP server for QURL - secure link management for AI agents",
+  "description": "MCP server for qURL - secure link management for AI agents",
   "type": "module",
   "bin": {
     "qurl-mcp": "./dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@layerv/qurl-mcp",
   "version": "0.1.2",
-  "description": "MCP server for qURL - secure link management for AI agents",
+  "description": "MCP server for qURL™ — secure link management for AI agents. Quantum URL is how you enter the hidden layer of the internet.",
   "type": "module",
   "bin": {
     "qurl-mcp": "./dist/index.js"

--- a/src/__tests__/resources/links.test.ts
+++ b/src/__tests__/resources/links.test.ts
@@ -28,7 +28,7 @@ describe("linksResource", () => {
 
     it("has a name", () => {
       const resource = linksResource(makeMockClient());
-      expect(resource.name).toBe("Active QURL Links");
+      expect(resource.name).toBe("Active qURL Links");
     });
 
     it("has correct mimeType", () => {

--- a/src/__tests__/resources/usage.test.ts
+++ b/src/__tests__/resources/usage.test.ts
@@ -33,7 +33,7 @@ describe("usageResource", () => {
 
     it("has a name", () => {
       const resource = usageResource(makeMockClient());
-      expect(resource.name).toBe("QURL Usage & Quota");
+      expect(resource.name).toBe("qURL Usage & Quota");
     });
 
     it("has correct mimeType", () => {

--- a/src/__tests__/tools/create-qurl.test.ts
+++ b/src/__tests__/tools/create-qurl.test.ts
@@ -14,7 +14,7 @@ describe("createQurlTool", () => {
     it("has a description", () => {
       const tool = createQurlTool(makeMockClient());
       expect(tool.description).toBeTruthy();
-      expect(tool.description).toContain("QURL");
+      expect(tool.description).toContain("qURL");
     });
   });
 

--- a/src/__tests__/tools/delete-qurl.test.ts
+++ b/src/__tests__/tools/delete-qurl.test.ts
@@ -65,7 +65,7 @@ describe("deleteQurlTool", () => {
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe("text");
-      expect(result.content[0].text).toBe("QURL r_abc123 has been revoked.");
+      expect(result.content[0].text).toBe("qURL r_abc123 has been revoked.");
     });
 
     it("propagates client errors", async () => {

--- a/src/__tests__/tools/extend-qurl.test.ts
+++ b/src/__tests__/tools/extend-qurl.test.ts
@@ -74,7 +74,7 @@ describe("extendQurlTool", () => {
       expect(mockExtend).toHaveBeenCalledWith("r_extend1", { extend_by: "48h" });
     });
 
-    it("returns updated QURL data as formatted JSON", async () => {
+    it("returns updated qURL data as formatted JSON", async () => {
       const mockExtend = vi.fn().mockResolvedValue({ data: fixture });
       const client = makeMockClient({ extendQURL: mockExtend });
       const tool = extendQurlTool(client);

--- a/src/__tests__/tools/update-qurl.test.ts
+++ b/src/__tests__/tools/update-qurl.test.ts
@@ -170,7 +170,7 @@ describe("updateQurlTool", () => {
       expect(mockUpdate).toHaveBeenCalledWith("r_update1", { extend_by: "48h" });
     });
 
-    it("returns updated QURL data as formatted JSON", async () => {
+    it("returns updated qURL data as formatted JSON", async () => {
       const mockUpdate = vi.fn().mockResolvedValue({ data: fixture });
       const client = makeMockClient({ updateQURL: mockUpdate });
       const tool = updateQurlTool(client);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 /**
- * QURL API client for the MCP server.
+ * qURL API client for the MCP server.
  */
 
 export interface QURLClientConfig {
@@ -202,7 +202,7 @@ export interface BatchCreateOutput {
 
 export interface IQURLClient {
   /**
-   * Create a new QURL. Returns `CreateQURLData` — the ephemeral create-time
+   * Create a new qURL. Returns `CreateQURLData` — the ephemeral create-time
    * shape that carries `qurl_link` (shown only once) and `qurl_id`. This is
    * intentionally distinct from the `QURL` shape returned by `getQURL` /
    * `listQURLs`, which does not include `qurl_link`.

--- a/src/prompts/audit-links.ts
+++ b/src/prompts/audit-links.ts
@@ -4,7 +4,7 @@ export function auditLinksPrompt() {
   return {
     name: "audit-links",
     description:
-      "Review all active QURLs and identify expiring links, token counts, missing metadata, or potential issues.",
+      "Review all active qURLs and identify expiring links, token counts, missing metadata, or potential issues.",
     handler: (): GetPromptResult => {
       return {
         messages: [
@@ -13,10 +13,10 @@ export function auditLinksPrompt() {
             content: {
               type: "text",
               text: [
-                "Audit my active QURL links. Follow these steps:",
+                "Audit my active qURL links. Follow these steps:",
                 "",
-                "1. Use the list_qurls tool to fetch all active QURLs.",
-                "2. For each QURL, collect facts:",
+                "1. Use the list_qurls tool to fetch all active qURLs.",
+                "2. For each qURL, collect facts:",
                 "   - Is it expiring within the next 24 hours? (flag as expiring-soon)",
                 "   - How many access tokens does it have (qurl_count)?",
                 "   - Is it missing tags for organization? (flag as untagged)",

--- a/src/prompts/rotate-access.ts
+++ b/src/prompts/rotate-access.ts
@@ -2,11 +2,11 @@ import { z } from "zod";
 import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 
 export const rotateAccessArgs = {
-  resource_id: z.string().describe("The resource ID of the QURL to rotate"),
+  resource_id: z.string().describe("The resource ID of the qURL to rotate"),
   expires_in: z
     .string()
     .optional()
-    .describe('New expiration duration for the replacement QURL (e.g., "24h", "7d")'),
+    .describe('New expiration duration for the replacement qURL (e.g., "24h", "7d")'),
 };
 
 type RotateAccessInput = z.infer<z.ZodObject<typeof rotateAccessArgs>>;
@@ -15,7 +15,7 @@ export function rotateAccessPrompt() {
   return {
     name: "rotate-access",
     description:
-      "Rotate a QURL by revoking the existing link and creating a fresh one with the same target.",
+      "Rotate a qURL by revoking the existing link and creating a fresh one with the same target.",
     args: rotateAccessArgs,
     handler: (args: RotateAccessInput): GetPromptResult => {
       const expiry = args.expires_in ?? "24h";
@@ -27,12 +27,12 @@ export function rotateAccessPrompt() {
             content: {
               type: "text",
               text: [
-                `Rotate access for QURL ${args.resource_id}. Follow these steps:`,
+                `Rotate access for qURL ${args.resource_id}. Follow these steps:`,
                 "",
                 `1. Use the get_qurl tool to fetch the current details for resource_id "${args.resource_id}".`,
-                "2. Note the target_url, tags, and description from the existing QURL — you will restore them on the new resource.",
-                `3. Use the delete_qurl tool to revoke the old QURL "${args.resource_id}".`,
-                `4. Use the create_qurl tool to create a new QURL with the same target_url, with expires_in set to "${expiry}". (tags and description live on the resource and are not accepted by create_qurl — they will be applied in the next step via update_qurl.)`,
+                "2. Note the target_url, tags, and description from the existing qURL — you will restore them on the new resource.",
+                `3. Use the delete_qurl tool to revoke the old qURL "${args.resource_id}".`,
+                `4. Use the create_qurl tool to create a new qURL with the same target_url, with expires_in set to "${expiry}". (tags and description live on the resource and are not accepted by create_qurl — they will be applied in the next step via update_qurl.)`,
                 "5. If the original had tags or a description, use the update_qurl tool on the new resource_id to restore them.",
                 "6. Confirm the rotation was successful and provide the new qurl_link from the create_qurl response.",
                 "",

--- a/src/prompts/secure-a-service.ts
+++ b/src/prompts/secure-a-service.ts
@@ -2,11 +2,11 @@ import { z } from "zod";
 import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 
 export const secureAServiceArgs = {
-  target_url: z.string().describe("The URL of the service to protect with QURL"),
+  target_url: z.string().describe("The URL of the service to protect with qURL"),
   label: z
     .string()
     .optional()
-    .describe("Human-readable label identifying who this QURL is for"),
+    .describe("Human-readable label identifying who this qURL is for"),
   description: z
     .string()
     .optional()
@@ -66,7 +66,7 @@ export function secureAServicePrompt() {
   return {
     name: "secure-a-service",
     description:
-      "Guide through creating a QURL to protect a service with appropriate security policies " +
+      "Guide through creating a qURL to protect a service with appropriate security policies " +
       "(expiration, session limits, IP/geo allowlists, AI-agent blocking).",
     args: secureAServiceArgs,
     handler: (args: SecureAServiceInput): GetPromptResult => {
@@ -120,7 +120,7 @@ export function secureAServicePrompt() {
         : [];
 
       const text = [
-        `Create a QURL to protect the following service: ${args.target_url}`,
+        `Create a qURL to protect the following service: ${args.target_url}`,
         ...(args.label ? [`Label: ${args.label}`] : []),
         ...(args.description ? [`Description: ${args.description}`] : []),
         "",
@@ -130,7 +130,7 @@ export function secureAServicePrompt() {
         ...policyLines,
         ...descriptionFollowUp,
         "",
-        "After creating the QURL, explain the returned qurl_link and how to share it securely. " +
+        "After creating the qURL, explain the returned qurl_link and how to share it securely. " +
           "Note that the qurl_link is ephemeral and shown only once — it should be shared immediately. " +
           "Note the expiration time and any access restrictions that were applied.",
       ].join("\n");

--- a/src/resources/links.ts
+++ b/src/resources/links.ts
@@ -9,9 +9,9 @@ export function linksResource(client: IQURLClient) {
   const mimeType = "application/json";
   return {
     uri,
-    name: "Active QURL Links",
+    name: "Active qURL Links",
     description:
-      `Snapshot of up to ${LINKS_RESOURCE_LIMIT} active QURL links (most recent first). ` +
+      `Snapshot of up to ${LINKS_RESOURCE_LIMIT} active qURL links (most recent first). ` +
       "For full pagination use the list_qurls tool.",
     mimeType,
     handler: async () => {

--- a/src/resources/usage.ts
+++ b/src/resources/usage.ts
@@ -5,7 +5,7 @@ export function usageResource(client: IQURLClient) {
   const mimeType = "application/json";
   return {
     uri,
-    name: "QURL Usage & Quota",
+    name: "qURL Usage & Quota",
     description: "Current quota and usage information",
     mimeType,
     handler: async () => {

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -23,7 +23,7 @@ export function zodErrorToToolResult(error: ZodError) {
 /**
  * Zod schema for a tool's resource_id parameter.
  *
- * The API accepts both a resource ID (r_ prefix) and a QURL display ID
+ * The API accepts both a resource ID (r_ prefix) and a qURL display ID
  * (q_ prefix) on get/update/extend/mint_link, and resolves a q_ ID to its
  * parent resource automatically. DELETE is the one exception — it only
  * accepts r_ IDs and defines its own schema.
@@ -36,7 +36,7 @@ export function resourceIdSchema(verb: string) {
     .string()
     .min(1)
     .describe(
-      `The resource ID (r_ prefix) or QURL display ID (q_ prefix) to ${verb}. ` +
+      `The resource ID (r_ prefix) or qURL display ID (q_ prefix) to ${verb}. ` +
         "If a q_ ID is passed, the API resolves it to the parent resource automatically.",
     );
 }

--- a/src/tools/batch-create.ts
+++ b/src/tools/batch-create.ts
@@ -7,14 +7,14 @@ export const batchCreateSchema = z.object({
     .array(createQurlSchema)
     .min(1)
     .max(100)
-    .describe("Array of QURL creation requests (1-100 items)"),
+    .describe("Array of qURL creation requests (1-100 items)"),
 });
 
 export function batchCreateTool(client: IQURLClient) {
   return {
     name: "batch_create_qurls",
     description:
-      "Create multiple QURLs in a single request. " +
+      "Create multiple qURLs in a single request. " +
       "Returns per-item results including any errors for partial failures. " +
       "The response sets isError=true when one or more items fail so agents can branch on partial failure without parsing the JSON.",
     inputSchema: batchCreateSchema,

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -42,12 +42,12 @@ export const accessPolicySchema = z.object({
 });
 
 export const createQurlSchema = z.object({
-  target_url: z.string().url().describe("The URL to protect with QURL"),
+  target_url: z.string().url().describe("The URL to protect with qURL"),
   label: z
     .string()
     .max(500)
     .optional()
-    .describe("Human-readable label identifying who this QURL is for (max 500 chars)"),
+    .describe("Human-readable label identifying who this qURL is for (max 500 chars)"),
   expires_in: z
     .string()
     .min(1)
@@ -67,14 +67,14 @@ export const createQurlSchema = z.object({
     .optional()
     .describe('How long access lasts after clicking (e.g., "1h")'),
   custom_domain: z.string().optional().describe("Custom domain to assign to the auto-created resource"),
-  access_policy: accessPolicySchema.optional().describe("Access control policy for the QURL"),
+  access_policy: accessPolicySchema.optional().describe("Access control policy for the qURL"),
 });
 
 export function createQurlTool(client: IQURLClient) {
   return {
     name: "create_qurl",
     description:
-      "Create a QURL - a secure, policy-bound link to a protected resource. " +
+      "Create a qURL - a secure, policy-bound link to a protected resource. " +
       "The returned qurl_link is ephemeral (shown once) and should be shared immediately.",
     inputSchema: createQurlSchema,
     handler: async (input: z.infer<typeof createQurlSchema>) => {

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -11,14 +11,14 @@ export const deleteQurlSchema = z.object({
     .min(1)
     .startsWith("r_", "delete_qurl only accepts resource IDs (r_ prefix). Use update_qurl or mint_link for q_ IDs.")
     .describe(
-      "The resource ID (must start with r_). delete_qurl does not accept q_ (QURL display) IDs.",
+      "The resource ID (must start with r_). delete_qurl does not accept q_ (qURL display) IDs.",
     ),
 });
 
 export function deleteQurlTool(client: IQURLClient) {
   return {
     name: "delete_qurl",
-    description: "Revoke/delete a QURL. This immediately invalidates the link.",
+    description: "Revoke/delete a qURL. This immediately invalidates the link.",
     inputSchema: deleteQurlSchema,
     handler: async (input: z.infer<typeof deleteQurlSchema>) => {
       await client.deleteQURL(input.resource_id);
@@ -26,7 +26,7 @@ export function deleteQurlTool(client: IQURLClient) {
         content: [
           {
             type: "text" as const,
-            text: `QURL ${input.resource_id} has been revoked.`,
+            text: `qURL ${input.resource_id} has been revoked.`,
           },
         ],
       };

--- a/src/tools/extend-qurl.ts
+++ b/src/tools/extend-qurl.ts
@@ -11,7 +11,7 @@ export function extendQurlTool(client: IQURLClient) {
   return {
     name: "extend_qurl",
     description:
-      "Extend the expiration of an active QURL. Accepts a resource ID (r_) or QURL display ID (q_). " +
+      "Extend the expiration of an active qURL. Accepts a resource ID (r_) or qURL display ID (q_). " +
       "Shorthand for update_qurl with only extend_by — use update_qurl for richer updates (tags, description, expiration).",
     inputSchema: extendQurlSchema,
     handler: async (input: z.infer<typeof extendQurlSchema>) => {

--- a/src/tools/get-qurl.ts
+++ b/src/tools/get-qurl.ts
@@ -10,8 +10,8 @@ export function getQurlTool(client: IQURLClient) {
   return {
     name: "get_qurl",
     description:
-      "Get details of a QURL resource and its access tokens. " +
-      "Accepts either a resource ID (r_ prefix) or a QURL display ID (q_ prefix).",
+      "Get details of a qURL resource and its access tokens. " +
+      "Accepts either a resource ID (r_ prefix) or a qURL display ID (q_ prefix).",
     inputSchema: getQurlSchema,
     handler: async (input: z.infer<typeof getQurlSchema>) => {
       const result = await client.getQURL(input.resource_id);

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -8,7 +8,7 @@ export const listQurlsSchema = z.object({
     .min(1)
     .max(100)
     .optional()
-    .describe("Maximum number of QURLs to return (default: 20)"),
+    .describe("Maximum number of qURLs to return (default: 20)"),
   cursor: z.string().optional().describe("Pagination cursor from a previous response"),
   // Plain string (not z.enum) because the API accepts comma-separated values like "active,revoked"
   status: z
@@ -43,7 +43,7 @@ export function listQurlsTool(client: IQURLClient) {
   return {
     name: "list_qurls",
     description:
-      "List QURLs with optional filtering by status, date ranges, and search query.",
+      "List qURLs with optional filtering by status, date ranges, and search query.",
     inputSchema: listQurlsSchema,
     handler: async (input: z.infer<typeof listQurlsSchema>) => {
       const result = await client.listQURLs(input);

--- a/src/tools/mint-link.ts
+++ b/src/tools/mint-link.ts
@@ -41,8 +41,8 @@ export function mintLinkTool(client: IQURLClient) {
   return {
     name: "mint_link",
     description:
-      "Mint a new access link for an existing QURL resource. " +
-      "Accepts either a resource ID (r_ prefix) or QURL display ID (q_ prefix). " +
+      "Mint a new access link for an existing qURL resource. " +
+      "Accepts either a resource ID (r_ prefix) or qURL display ID (q_ prefix). " +
       "Use this to generate additional access links without creating a new resource. " +
       "Do not provide both expires_in and expires_at.",
     inputSchema: mintLinkBaseSchema,

--- a/src/tools/resolve-qurl.ts
+++ b/src/tools/resolve-qurl.ts
@@ -5,14 +5,14 @@ export const resolveQurlSchema = z.object({
   access_token: z
     .string()
     .min(1)
-    .describe("The access token from a QURL link (e.g., at_k8xqp9h2sj9lx7r4a)"),
+    .describe("The access token from a qURL link (e.g., at_k8xqp9h2sj9lx7r4a)"),
 });
 
 export function resolveQurlTool(client: IQURLClient) {
   return {
     name: "resolve_qurl",
     description:
-      "Resolve a QURL access token to get the target URL and open firewall access. " +
+      "Resolve a qURL access token to get the target URL and open firewall access. " +
       "After resolution, the target URL is accessible from your IP for the duration " +
       "specified in access_grant.expires_in seconds.",
     inputSchema: resolveQurlSchema,

--- a/src/tools/update-qurl.ts
+++ b/src/tools/update-qurl.ts
@@ -54,8 +54,8 @@ export function updateQurlTool(client: IQURLClient) {
   return {
     name: "update_qurl",
     description:
-      "Update a QURL - extend expiration, set an absolute expiry, update tags, or change the description. " +
-      "Accepts either a resource ID (r_ prefix) or QURL display ID (q_ prefix). " +
+      "Update a qURL - extend expiration, set an absolute expiry, update tags, or change the description. " +
+      "Accepts either a resource ID (r_ prefix) or qURL display ID (q_ prefix). " +
       "Do not provide both extend_by and expires_at. At least one update field is required.",
     // Base shape for MCP tool registration; refinements run in the handler
     inputSchema: updateQurlBaseSchema,


### PR DESCRIPTION
## Summary

Updates the brand spelling to **qURL** (case-sensitive) across user-visible strings, documentation, code comments, MCP tool descriptions, and the prompts/resources surface.

## Why

The product brand is `qURL`. Tool descriptions, README, and on-the-wire response text were inconsistently spelled `QURL` / `Qurl` / `qurl`. AI agents that introspect this server's tools/resources/prompts will now see consistent brand text. README and `package.json` `description` are what npm and the npm landing page display.

## What changed

- `README.md`, `CLAUDE.md`, `package.json` description
- MCP tool descriptions, `.describe()` strings, prompt text
- `src/resources/{links,usage}.ts` resource `name` and `description`
- Code comments and JSDoc prose
- Tool response strings (e.g. `qURL r_… has been revoked.`)
- Test assertions updated in lockstep with the source strings above

## What was intentionally not changed

Identifier-style references kept as-is to avoid breaking anything:

- TS type / method names: `QURL`, `QURLClient`, `QURLAPIError`, `IQURLClient`, `getQURL`, `listQURLs`, `createQURL`, …
- Env vars: `QURL_API_KEY`, `QURL_API_URL`, `QURL_API_SPEC_URL`
- npm package name `@layerv/qurl-mcp` and bin name `qurl-mcp`
- Tool names and scope identifiers: `create_qurl`, `qurl:read`, `qurl:write`, `qurl:resolve`, …
- URI scheme: `qurl://links`, `qurl://usage`
- Repo URLs / slugs

`api-spec/qurls.yaml` is intentionally not edited — it's a snapshot auto-synced from the upstream OpenAPI spec by `.github/workflows/api-spec-check.yml` (weekly). Once the upstream description fields are rebranded, the drift-check workflow will open an issue to re-sync this file.

A handful of test fixtures keep `QURL` (e.g. mock error `detail` strings that mirror upstream API responses, the `description: "Test QURL"` test label) — these don't affect behavior and will be updated alongside the upstream API rebrand to keep mocks accurate.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` — 253/253 pass
- [x] Grep verification: `git grep -E '\bqurl\b' -- '*.md' '*.ts'` returns no non-identifier prose hits