### PR TITLE
feat: register with MCP Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@layerv/qurl-mcp",
   "version": "0.2.0",
   "description": "MCP server for qURL™ — secure link management for AI agents. Quantum URL is how you enter the hidden layer of the internet.",
+  "mcpName": "io.github.layervai/qurl-mcp",
   "type": "module",
   "bin": {
     "qurl-mcp": "./dist/index.js"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.layervai/qurl-mcp",
+  "title": "qURL",
+  "description": "Mint, resolve, audit, and rotate expiring, scope-limited access links (qURLs) for AI agents — secure URL gateway for the qURL API. Lets agents act through scoped, expiring URLs instead of receiving raw credentials.",
+  "websiteUrl": "https://layerv.ai",
+  "repository": {
+    "url": "https://github.com/layervai/qurl-mcp",
+    "source": "github"
+  },
+  "version": "0.2.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@layerv/qurl-mcp",
+      "version": "0.2.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "QURL_API_KEY",
+          "description": "API key for the qURL API with qurl:read, qurl:write, and/or qurl:resolve scopes. Obtain from https://layerv.ai.",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "QURL_API_URL",
+          "description": "qURL API base URL. Defaults to https://api.layerv.ai.",
+          "isRequired": false,
+          "format": "string",
+          "default": "https://api.layerv.ai"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Prepares qurl-mcp for publication on the official **[MCP Registry](https://registry.modelcontextprotocol.io/)** — the canonical discovery surface for MCP servers (the upstream `modelcontextprotocol/servers` README is now reserved for steering-group reference servers and explicitly redirects community servers to the Registry).

Two changes:

1. **`package.json`** — adds `"mcpName": "io.github.layervai/qurl-mcp"`. The Registry uses this field to verify that the npm package matches the metadata at publish time. The `io.github.layervai/...` prefix locks ownership to the `layervai` GitHub org.
2. **`server.json`** — new file declaring the server's Registry manifest: name, description, stdio transport, npm package identifier, and the `QURL_API_KEY` / `QURL_API_URL` environment variables.

## Why this triggers a release

Marked `feat:` so Release Please cuts a **0.2.1** patch (current `bump-patch-for-minor-pre-major: true` config in `release-please-config.json` keeps feats at patch-level pre-1.0). Republishing 0.2.1 to npm is required because the Registry's verification step reads `mcpName` from the *published* artifact's `package.json` — 0.2.0 doesn't have it.

## Release Flow

1. Merge this PR
2. Release Please opens release PR for 0.2.1
3. Merge release PR → tag `qurl-mcp-v0.2.1` → npm publish runs
4. **Manual step (interactive auth, owner only):**
   ```bash
   brew install mcp-publisher  # or use the binary install
   mcp-publisher login github  # device-code flow
   mcp-publisher publish       # reads server.json
   ```
5. Verify at https://registry.modelcontextprotocol.io/v0/servers?search=qurl

## Test plan

- [x] `npm run build && npm run lint && npm test` green (253/253)
- [x] `server.json` validates against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- [ ] CI green on this PR
- [ ] Release-please cuts 0.2.1 after merge
- [ ] `npm view @layerv/qurl-mcp version` reports 0.2.1
- [ ] `mcp-publisher publish` succeeds (manual)