### PR TITLE
chore: add MIT LICENSE file at repo root

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LayerV AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Why

\`package.json\` has declared \`\"license\": \"MIT\"\` since v0.1.0, but **Glama** (https://glama.ai/mcp/servers/layervai/qurl-mcp), GitHub's auto-detection, and most license-checker tools look for a \`LICENSE\` file at the repo root specifically — not the package manifest. Without it the package is reported as "license not found." Glama is currently giving us an **F** rating purely on this signal.

## What

Standard MIT license text at \`/LICENSE\`. Copyright held by **LayerV AI** (matches \`package.json\`'s \`"author": "LayerV AI"\` and the README's footer attribution).

## Effect

- GitHub repo page will start showing the **"MIT license"** badge in the right sidebar.
- Glama's next re-scan will pick it up and the rating recovers.
- npm provenance + the \`org.opencontainers.image.licenses="MIT"\` Docker label both stay consistent with the now-shipped license file.
- License-checker tools used by downstream consumers (e.g. enterprise license-compliance scanners) will resolve cleanly.

## Test plan

- [x] Standard SPDX-recognized MIT text
- [x] Copyright holder matches existing attribution
- [ ] CI green