### PR TITLE
feat(tools): add output schemas, annotations, and richer descriptions for TDQS

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"95baaf8e-5366-4feb-8aa2-bd97466537e2","pid":31627,"procStart":"Mon Apr 27 17:35:40 2026","acquiredAt":1777311573120}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"95baaf8e-5366-4feb-8aa2-bd97466537e2","pid":31627,"procStart":"Mon Apr 27 17:35:40 2026","acquiredAt":1777311573120}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ Thumbs.db
 *.swp
 *.swo
 
+# Claude Code local state
+.claude/
+
 # Environment
 .env
 .env.local

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,5 +1,12 @@
 import { vi } from "vitest";
-import type { IQURLClient, QURL, CreateQURLData } from "../client.js";
+import type {
+  BatchCreateOutput,
+  CreateQURLData,
+  IQURLClient,
+  MintLinkOutput,
+  QURL,
+  ResolveOutput,
+} from "../client.js";
 import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 
 export function makeMockClient(overrides: Partial<IQURLClient> = {}): IQURLClient {
@@ -47,5 +54,49 @@ export function sampleCreateQURLData(overrides: Partial<CreateQURLData> = {}): C
     qurl_site: "https://q_3a7f2c8e91b.qurl.site",
     expires_at: "2026-03-10T00:00:00Z",
     ...overrides,
+  };
+}
+
+export function sampleResolveOutput(overrides: Partial<ResolveOutput> = {}): ResolveOutput {
+  return {
+    target_url: "https://example.com/secret",
+    resource_id: "r_resolved1",
+    access_grant: {
+      expires_in: 300,
+      granted_at: "2026-03-09T12:00:00Z",
+      src_ip: "192.168.1.100",
+    },
+    ...overrides,
+  };
+}
+
+export function sampleMintLinkOutput(overrides: Partial<MintLinkOutput> = {}): MintLinkOutput {
+  return {
+    qurl_link: "https://qurl.link/at_xyz",
+    expires_at: "2026-03-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+export function sampleBatchCreateOutput(
+  overrides: Partial<BatchCreateOutput["data"]> = {},
+): BatchCreateOutput {
+  return {
+    data: {
+      succeeded: 1,
+      failed: 0,
+      results: [
+        {
+          index: 0,
+          success: true,
+          resource_id: "r_test123",
+          qurl_link: "https://qurl.link/at_abc",
+          qurl_site: "https://q_x.qurl.site",
+          expires_at: "2026-03-10T00:00:00Z",
+        },
+      ],
+      ...overrides,
+    },
+    meta: { request_id: "req_batch" },
   };
 }

--- a/src/__tests__/output-schemas.types.test.ts
+++ b/src/__tests__/output-schemas.types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expectTypeOf } from "vitest";
 import type { z } from "zod";
 import type {
+  BatchCreateOutput,
   CreateQURLData,
   ListQURLsOutput,
   MintLinkOutput,
@@ -8,6 +9,7 @@ import type {
   ResolveOutput,
 } from "../client.js";
 import {
+  batchCreateOutputSchema,
   createQurlOutputSchema,
   listQurlsOutputSchema,
   mintLinkOutputSchema,
@@ -20,10 +22,9 @@ import {
 // covers external (API <-> snapshot) drift; this guards internal
 // (client.ts <-> output-schemas.ts) drift.
 //
-// Intentionally omitted: `batchCreateOutputSchema` (flattens `{data, meta}`
-// envelope into one object — see comment in output-schemas.ts) and
-// `deleteQurlOutputSchema` (no client-side interface; the client returns
-// `Promise<void>` and the handler synthesizes the payload).
+// `deleteQurlOutputSchema` is intentionally omitted (no client-side
+// interface — the client returns `Promise<void>` and the handler
+// synthesizes the payload).
 describe("output schema <-> client type alignment", () => {
   it("qurlSchema matches QURL", () => {
     expectTypeOf<z.infer<typeof qurlSchema>>().toEqualTypeOf<QURL>();
@@ -43,5 +44,13 @@ describe("output schema <-> client type alignment", () => {
 
   it("mintLinkOutputSchema matches MintLinkOutput", () => {
     expectTypeOf<z.infer<typeof mintLinkOutputSchema>>().toEqualTypeOf<MintLinkOutput>();
+  });
+
+  it("batchCreateOutputSchema matches the flattened BatchCreateOutput.data + request_id", () => {
+    // Schema flattens the `{ data, meta }` envelope; assert against the
+    // flattened shape so a new field on `BatchCreateOutput.data` is a
+    // compile error here.
+    type FlatBatchPayload = BatchCreateOutput["data"] & { request_id?: string };
+    expectTypeOf<z.infer<typeof batchCreateOutputSchema>>().toEqualTypeOf<FlatBatchPayload>();
   });
 });

--- a/src/__tests__/output-schemas.types.test.ts
+++ b/src/__tests__/output-schemas.types.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expectTypeOf } from "vitest";
+import type { z } from "zod";
+import type {
+  CreateQURLData,
+  ListQURLsOutput,
+  MintLinkOutput,
+  QURL,
+  ResolveOutput,
+} from "../client.js";
+import {
+  createQurlOutputSchema,
+  listQurlsOutputSchema,
+  mintLinkOutputSchema,
+  qurlSchema,
+  resolveQurlOutputSchema,
+} from "../tools/output-schemas.js";
+
+// Lock each Zod output schema to its corresponding client interface so a
+// new field on either side breaks compilation. The MCP-spec-drift workflow
+// covers external (API <-> snapshot) drift; this guards internal
+// (client.ts <-> output-schemas.ts) drift.
+describe("output schema <-> client type alignment", () => {
+  it("qurlSchema matches QURL", () => {
+    expectTypeOf<z.infer<typeof qurlSchema>>().toEqualTypeOf<QURL>();
+  });
+
+  it("createQurlOutputSchema matches CreateQURLData", () => {
+    expectTypeOf<z.infer<typeof createQurlOutputSchema>>().toEqualTypeOf<CreateQURLData>();
+  });
+
+  it("listQurlsOutputSchema matches ListQURLsOutput", () => {
+    expectTypeOf<z.infer<typeof listQurlsOutputSchema>>().toEqualTypeOf<ListQURLsOutput>();
+  });
+
+  it("resolveQurlOutputSchema matches ResolveOutput", () => {
+    expectTypeOf<z.infer<typeof resolveQurlOutputSchema>>().toEqualTypeOf<ResolveOutput>();
+  });
+
+  it("mintLinkOutputSchema matches MintLinkOutput", () => {
+    expectTypeOf<z.infer<typeof mintLinkOutputSchema>>().toEqualTypeOf<MintLinkOutput>();
+  });
+});

--- a/src/__tests__/output-schemas.types.test.ts
+++ b/src/__tests__/output-schemas.types.test.ts
@@ -19,6 +19,11 @@ import {
 // new field on either side breaks compilation. The MCP-spec-drift workflow
 // covers external (API <-> snapshot) drift; this guards internal
 // (client.ts <-> output-schemas.ts) drift.
+//
+// Intentionally omitted: `batchCreateOutputSchema` (flattens `{data, meta}`
+// envelope into one object — see comment in output-schemas.ts) and
+// `deleteQurlOutputSchema` (no client-side interface; the client returns
+// `Promise<void>` and the handler synthesizes the payload).
 describe("output schema <-> client type alignment", () => {
   it("qurlSchema matches QURL", () => {
     expectTypeOf<z.infer<typeof qurlSchema>>().toEqualTypeOf<QURL>();

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -50,6 +50,28 @@ describe("TDQS tool metadata coverage", () => {
     });
   }
 
+  describe("disambiguation guidance in descriptions", () => {
+    // The 80-char floor catches missing rich text but not 200-char fluff.
+    // For tools that overlap with siblings, lock in the "Use `xxx` instead"
+    // guidance so an inattentive description rewrite can't drop it.
+    const expected: Record<string, string[]> = {
+      delete_qurl: ["update_qurl"],
+      update_qurl: ["extend_qurl", "delete_qurl"],
+      extend_qurl: ["update_qurl"],
+      mint_link: ["create_qurl", "update_qurl"],
+      batch_create_qurls: ["create_qurl"],
+    };
+    const byName = new Map(tools.map((t) => [t.name, t]));
+    for (const [name, siblings] of Object.entries(expected)) {
+      it(`${name} description references ${siblings.join(", ")}`, () => {
+        const description = byName.get(name)?.description ?? "";
+        for (const sibling of siblings) {
+          expect(description).toContain(sibling);
+        }
+      });
+    }
+  });
+
   describe("safety hints match tool semantics", () => {
     const byName = new Map(tools.map((t) => [t.name, t]));
 

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import type { IQURLClient } from "../client.js";
 import { toolFactories } from "../server.js";
-import { deleteQurlTool } from "../tools/delete-qurl.js";
-import { makeMockClient } from "./helpers.js";
+import {
+  makeMockClient,
+  sampleBatchCreateOutput,
+  sampleCreateQURLData,
+  sampleMintLinkOutput,
+  sampleQURL,
+  sampleResolveOutput,
+} from "./helpers.js";
 
 const tools = toolFactories.map((factory) => factory(makeMockClient()));
+const factoryByName = new Map(tools.map((tool, i) => [tool.name, toolFactories[i]]));
 
 describe("TDQS tool metadata coverage", () => {
   for (const tool of tools) {
@@ -43,6 +51,8 @@ describe("TDQS tool metadata coverage", () => {
   }
 
   describe("safety hints match tool semantics", () => {
+    const byName = new Map(tools.map((t) => [t.name, t]));
+
     it("marks read-only tools as readOnlyHint", () => {
       const readOnlyNames = new Set(["list_qurls", "get_qurl"]);
       for (const tool of tools) {
@@ -56,8 +66,94 @@ describe("TDQS tool metadata coverage", () => {
     });
 
     it("marks delete_qurl as destructiveHint", () => {
-      const tool = deleteQurlTool(makeMockClient());
-      expect(tool.annotations.destructiveHint).toBe(true);
+      expect(byName.get("delete_qurl")?.annotations.destructiveHint).toBe(true);
     });
+  });
+});
+
+/**
+ * Round-trip contract for every tool: `structuredContent` validates
+ * against the declared `outputSchema`, and (where text is JSON) the two
+ * views agree. Without this, schema/handler drift would only fail at
+ * host call time. delete_qurl is an intentional exception — its text is
+ * a human-readable confirmation, not the JSON payload.
+ */
+describe("structuredContent ↔ outputSchema round-trip", () => {
+  type Case = {
+    // Generic over 9 schemas, so input is loosely typed; per-tool tests
+    // exercise the strict input schema.
+    input: Record<string, unknown>;
+    clientOverrides: Partial<IQURLClient>;
+    textIsJson?: boolean;
+  };
+
+  const qurlFixture = sampleQURL();
+  const cases: Record<string, Case> = {
+    create_qurl: {
+      input: { target_url: "https://example.com" },
+      clientOverrides: {
+        createQURL: vi.fn().mockResolvedValue({ data: sampleCreateQURLData() }),
+      },
+    },
+    resolve_qurl: {
+      input: { access_token: "at_abc123def456" },
+      clientOverrides: {
+        resolveQURL: vi.fn().mockResolvedValue({ data: sampleResolveOutput() }),
+      },
+    },
+    list_qurls: {
+      input: {},
+      clientOverrides: {
+        listQURLs: vi.fn().mockResolvedValue({ data: [qurlFixture], meta: { has_more: false } }),
+      },
+    },
+    get_qurl: {
+      input: { resource_id: "r_test123" },
+      clientOverrides: { getQURL: vi.fn().mockResolvedValue({ data: qurlFixture }) },
+    },
+    delete_qurl: {
+      input: { resource_id: "r_test123" },
+      clientOverrides: { deleteQURL: vi.fn().mockResolvedValue(undefined) },
+      textIsJson: false,
+    },
+    extend_qurl: {
+      input: { resource_id: "r_test123", extend_by: "24h" },
+      clientOverrides: { extendQURL: vi.fn().mockResolvedValue({ data: qurlFixture }) },
+    },
+    update_qurl: {
+      input: { resource_id: "r_test123", extend_by: "24h" },
+      clientOverrides: { updateQURL: vi.fn().mockResolvedValue({ data: qurlFixture }) },
+    },
+    mint_link: {
+      input: { resource_id: "r_test123" },
+      clientOverrides: {
+        mintLink: vi.fn().mockResolvedValue({ data: sampleMintLinkOutput() }),
+      },
+    },
+    batch_create_qurls: {
+      input: { items: [{ target_url: "https://example.com" }] },
+      clientOverrides: { batchCreate: vi.fn().mockResolvedValue(sampleBatchCreateOutput()) },
+    },
+  };
+
+  for (const [name, { input, clientOverrides, textIsJson = true }] of Object.entries(cases)) {
+    it(`${name} structuredContent validates against outputSchema`, async () => {
+      const factory = factoryByName.get(name);
+      if (!factory) throw new Error(`Unknown tool ${name}`);
+      const tool = factory(makeMockClient(clientOverrides));
+
+      const result = await tool.handler(input);
+
+      expect(result.structuredContent).toBeDefined();
+      if (textIsJson) {
+        expect(result.structuredContent).toEqual(JSON.parse(result.content[0].text));
+      }
+      const parsed = tool.outputSchema.safeParse(result.structuredContent);
+      expect(parsed.success).toBe(true);
+    });
+  }
+
+  it("covers every registered tool", () => {
+    expect(new Set(Object.keys(cases))).toEqual(new Set(tools.map((t) => t.name)));
   });
 });

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -11,7 +11,9 @@ import {
 } from "./helpers.js";
 
 const tools = toolFactories.map((factory) => factory(makeMockClient()));
-const factoryByName = new Map(tools.map((tool, i) => [tool.name, toolFactories[i]]));
+const factoryByName = new Map(
+  toolFactories.map((factory) => [factory(makeMockClient()).name, factory] as const),
+);
 
 describe("TDQS tool metadata coverage", () => {
   for (const tool of tools) {

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { toolFactories } from "../server.js";
+import { deleteQurlTool } from "../tools/delete-qurl.js";
+import { makeMockClient } from "./helpers.js";
+
+const tools = toolFactories.map((factory) => factory(makeMockClient()));
+
+describe("TDQS tool metadata coverage", () => {
+  for (const tool of tools) {
+    describe(tool.name, () => {
+      it("declares a non-empty title", () => {
+        expect(tool.title).toBeTruthy();
+        expect(typeof tool.title).toBe("string");
+      });
+
+      it("has a substantive description (>= 80 chars)", () => {
+        expect(tool.description.length).toBeGreaterThanOrEqual(80);
+      });
+
+      it("declares an inputSchema as a ZodObject", () => {
+        expect(tool.inputSchema).toBeDefined();
+        // Duck-type via `.shape` so this stays robust to Zod major-version drift.
+        expect(typeof tool.inputSchema.shape).toBe("object");
+      });
+
+      it("declares an outputSchema as a ZodObject", () => {
+        expect(tool.outputSchema).toBeDefined();
+        expect(typeof tool.outputSchema.shape).toBe("object");
+        expect(Object.keys(tool.outputSchema.shape).length).toBeGreaterThan(0);
+      });
+
+      it("declares all four canonical annotations as booleans", () => {
+        expect(typeof tool.annotations.readOnlyHint).toBe("boolean");
+        expect(typeof tool.annotations.destructiveHint).toBe("boolean");
+        expect(typeof tool.annotations.idempotentHint).toBe("boolean");
+        expect(typeof tool.annotations.openWorldHint).toBe("boolean");
+      });
+
+      it("sets openWorldHint=true (every tool talks to the qURL API)", () => {
+        expect(tool.annotations.openWorldHint).toBe(true);
+      });
+    });
+  }
+
+  describe("safety hints match tool semantics", () => {
+    it("marks read-only tools as readOnlyHint", () => {
+      const readOnlyNames = new Set(["list_qurls", "get_qurl"]);
+      for (const tool of tools) {
+        if (readOnlyNames.has(tool.name)) {
+          expect(tool.annotations.readOnlyHint).toBe(true);
+          expect(tool.annotations.destructiveHint).toBe(false);
+        } else {
+          expect(tool.annotations.readOnlyHint).toBe(false);
+        }
+      }
+    });
+
+    it("marks delete_qurl as destructiveHint", () => {
+      const tool = deleteQurlTool(makeMockClient());
+      expect(tool.annotations.destructiveHint).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -49,6 +49,13 @@ describe("TDQS tool metadata coverage", () => {
       it("sets openWorldHint=true (every tool talks to the qURL API)", () => {
         expect(tool.annotations.openWorldHint).toBe(true);
       });
+
+      it("keeps top-level title and annotations.title in sync", () => {
+        // Both fields are spec-distinct (different consumers), but every
+        // tool in this repo uses the same string for both. Lock that
+        // convention so a future divergence is intentional, not drift.
+        expect(tool.annotations.title).toBe(tool.title);
+      });
     });
   }
 

--- a/src/__tests__/tools/batch-create.test.ts
+++ b/src/__tests__/tools/batch-create.test.ts
@@ -21,7 +21,9 @@ describe("batchCreateTool", () => {
     it("has a description", () => {
       const tool = batchCreateTool(makeMockClient());
       expect(tool.description).toBeTruthy();
-      expect(tool.description).toContain("multiple");
+      // Batch is the "many qURLs in one call" alternative to looping create_qurl —
+      // any of these markers is enough to confirm the description still names that purpose.
+      expect(tool.description).toMatch(/up to 100|many|multiple|batch/i);
     });
   });
 

--- a/src/__tests__/tools/create-qurl.test.ts
+++ b/src/__tests__/tools/create-qurl.test.ts
@@ -153,6 +153,19 @@ describe("createQurlTool", () => {
       expect(parsed.qurl_id).toBe("q_3a7f2c8e91b");
     });
 
+    it("returns structuredContent that matches the declared outputSchema", async () => {
+      const mockCreate = vi.fn().mockResolvedValue({ data: fixture });
+      const client = makeMockClient({ createQURL: mockCreate });
+      const tool = createQurlTool(client);
+
+      const result = await tool.handler({ target_url: "https://example.com" });
+
+      expect(result.structuredContent).toBeDefined();
+      expect(result.structuredContent).toEqual(JSON.parse(result.content[0].text));
+      const parsed = tool.outputSchema.safeParse(result.structuredContent);
+      expect(parsed.success).toBe(true);
+    });
+
     it("formats response as compact JSON", async () => {
       const mockCreate = vi.fn().mockResolvedValue({ data: fixture });
       const client = makeMockClient({ createQURL: mockCreate });

--- a/src/__tests__/tools/delete-qurl.test.ts
+++ b/src/__tests__/tools/delete-qurl.test.ts
@@ -77,7 +77,7 @@ describe("deleteQurlTool", () => {
       await expect(tool.handler({ resource_id: "r_abc" })).rejects.toThrow("Forbidden");
     });
 
-    it("swallows 404 from a re-delete and returns the same payload", async () => {
+    it("swallows 404 from a re-delete and flags was_already_revoked", async () => {
       const mockDelete = vi
         .fn()
         .mockRejectedValue(new QURLAPIError(404, "not_found", "Resource not found."));
@@ -90,7 +90,20 @@ describe("deleteQurlTool", () => {
       expect(result.structuredContent).toEqual({
         resource_id: "r_abc123",
         revoked: true,
+        was_already_revoked: true,
         message: "qURL r_abc123 is revoked.",
+      });
+    });
+
+    it("sets was_already_revoked: false on a fresh delete", async () => {
+      const mockDelete = vi.fn().mockResolvedValue(undefined);
+      const client = makeMockClient({ deleteQURL: mockDelete });
+      const tool = deleteQurlTool(client);
+
+      const result = await tool.handler({ resource_id: "r_abc123" });
+
+      expect(result.structuredContent).toMatchObject({
+        was_already_revoked: false,
       });
     });
 

--- a/src/__tests__/tools/delete-qurl.test.ts
+++ b/src/__tests__/tools/delete-qurl.test.ts
@@ -11,7 +11,7 @@ describe("deleteQurlTool", () => {
 
     it("has a description mentioning revoke", () => {
       const tool = deleteQurlTool(makeMockClient());
-      expect(tool.description).toContain("Revoke");
+      expect(tool.description.toLowerCase()).toContain("revoke");
     });
   });
 

--- a/src/__tests__/tools/delete-qurl.test.ts
+++ b/src/__tests__/tools/delete-qurl.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { QURLAPIError } from "../../client.js";
 import { deleteQurlTool, deleteQurlSchema } from "../../tools/delete-qurl.js";
 import { makeMockClient } from "../helpers.js";
 
@@ -74,6 +75,35 @@ describe("deleteQurlTool", () => {
       const tool = deleteQurlTool(client);
 
       await expect(tool.handler({ resource_id: "r_abc" })).rejects.toThrow("Forbidden");
+    });
+
+    it("swallows 404 from a re-delete and returns the same payload", async () => {
+      const mockDelete = vi
+        .fn()
+        .mockRejectedValue(new QURLAPIError(404, "not_found", "Resource not found."));
+      const client = makeMockClient({ deleteQURL: mockDelete });
+      const tool = deleteQurlTool(client);
+
+      const result = await tool.handler({ resource_id: "r_abc123" });
+
+      expect(result.content[0].text).toBe("qURL r_abc123 has been revoked.");
+      expect(result.structuredContent).toEqual({
+        resource_id: "r_abc123",
+        revoked: true,
+        message: "qURL r_abc123 has been revoked.",
+      });
+    });
+
+    it("propagates non-404 QURLAPIErrors", async () => {
+      const mockDelete = vi
+        .fn()
+        .mockRejectedValue(new QURLAPIError(403, "forbidden", "Insufficient permissions."));
+      const client = makeMockClient({ deleteQURL: mockDelete });
+      const tool = deleteQurlTool(client);
+
+      await expect(tool.handler({ resource_id: "r_abc" })).rejects.toThrow(
+        "Insufficient permissions.",
+      );
     });
   });
 });

--- a/src/__tests__/tools/delete-qurl.test.ts
+++ b/src/__tests__/tools/delete-qurl.test.ts
@@ -66,7 +66,7 @@ describe("deleteQurlTool", () => {
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe("text");
-      expect(result.content[0].text).toBe("qURL r_abc123 has been revoked.");
+      expect(result.content[0].text).toBe("qURL r_abc123 is revoked.");
     });
 
     it("propagates client errors", async () => {
@@ -86,11 +86,11 @@ describe("deleteQurlTool", () => {
 
       const result = await tool.handler({ resource_id: "r_abc123" });
 
-      expect(result.content[0].text).toBe("qURL r_abc123 has been revoked.");
+      expect(result.content[0].text).toBe("qURL r_abc123 is revoked.");
       expect(result.structuredContent).toEqual({
         resource_id: "r_abc123",
         revoked: true,
-        message: "qURL r_abc123 has been revoked.",
+        message: "qURL r_abc123 is revoked.",
       });
     });
 

--- a/src/__tests__/tools/resolve-qurl.test.ts
+++ b/src/__tests__/tools/resolve-qurl.test.ts
@@ -1,17 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { resolveQurlTool, resolveQurlSchema } from "../../tools/resolve-qurl.js";
-import type { ResolveOutput } from "../../client.js";
-import { makeMockClient } from "../helpers.js";
+import { makeMockClient, sampleResolveOutput as makeResolveOutput } from "../helpers.js";
 
-const sampleResolveOutput: ResolveOutput = {
-  target_url: "https://example.com/secret",
-  resource_id: "r_resolved1",
-  access_grant: {
-    expires_in: 300,
-    granted_at: "2026-03-09T12:00:00Z",
-    src_ip: "192.168.1.100",
-  },
-};
+const sampleResolveOutput = makeResolveOutput();
 
 describe("resolveQurlTool", () => {
   describe("metadata", () => {

--- a/src/__tests__/tools/resolve-qurl.test.ts
+++ b/src/__tests__/tools/resolve-qurl.test.ts
@@ -22,7 +22,7 @@ describe("resolveQurlTool", () => {
 
     it("has a description mentioning resolve and firewall", () => {
       const tool = resolveQurlTool(makeMockClient());
-      expect(tool.description).toContain("Resolve");
+      expect(tool.description.toLowerCase()).toContain("resolve");
       expect(tool.description).toContain("firewall");
     });
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -174,18 +174,28 @@ export interface MintLinkOutput {
   expires_at: string;
 }
 
-export interface BatchItemResult {
-  index: number;
-  success: boolean;
-  resource_id?: string;
-  qurl_link?: string;
-  qurl_site?: string;
-  expires_at?: string;
-  error?: {
-    code: string;
-    message: string;
-  };
-}
+// Discriminated on `success` so consumers narrowing on the boolean get
+// type-safe access to the success-only fields (qurl_link, etc.) and the
+// failure-only `error` shape. The API contract is mutually exclusive at
+// the per-item level — a result either succeeded or carries an error,
+// never both.
+export type BatchItemResult =
+  | {
+      index: number;
+      success: true;
+      resource_id: string;
+      qurl_link: string;
+      qurl_site: string;
+      expires_at: string;
+    }
+  | {
+      index: number;
+      success: false;
+      error: {
+        code: string;
+        message: string;
+      };
+    };
 
 export interface BatchCreateOutput {
   data: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ export type ToolFactory = (client: IQURLClient) => {
   // Args vary per tool; exact signatures are validated by registerTool at each call site.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handler: (...args: any[]) => Promise<{
-    content: Array<{ type: string; text: string }>;
+    content: Array<{ type: "text"; text: string }>;
     structuredContent?: Record<string, unknown>;
     isError?: boolean;
   }>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,21 +10,31 @@ import { extendQurlTool } from "./tools/extend-qurl.js";
 import { updateQurlTool } from "./tools/update-qurl.js";
 import { mintLinkTool } from "./tools/mint-link.js";
 import { batchCreateTool } from "./tools/batch-create.js";
+import type { ToolAnnotations } from "./tools/_shared.js";
 import { linksResource } from "./resources/links.js";
 import { usageResource } from "./resources/usage.js";
 import { secureAServicePrompt } from "./prompts/secure-a-service.js";
 import { auditLinksPrompt } from "./prompts/audit-links.js";
 import { rotateAccessPrompt } from "./prompts/rotate-access.js";
 
-/** Shared contract for the objects returned by tool factory functions. */
+/**
+ * Shared contract for the objects returned by tool factory functions. Each
+ * tool exports the full `registerTool` config object so the SDK forwards
+ * `outputSchema` and `annotations` into the MCP `tools/list` response —
+ * downstream agents and TDQS scoring rely on those being present.
+ */
 type ToolFactory = (client: IQURLClient) => {
   name: string;
+  title: string;
   description: string;
   inputSchema: z.AnyZodObject;
-  // Args vary per tool; exact signatures are validated by server.tool() at each call site.
+  outputSchema: z.ZodTypeAny;
+  annotations: ToolAnnotations;
+  // Args vary per tool; exact signatures are validated by registerTool at each call site.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handler: (...args: any[]) => Promise<{
     content: Array<{ type: string; text: string }>;
+    structuredContent?: Record<string, unknown>;
     isError?: boolean;
   }>;
 };
@@ -50,7 +60,25 @@ export function createServer(client: IQURLClient, version: string): McpServer {
 
   for (const factory of toolFactories) {
     const tool = factory(client);
-    server.tool(tool.name, tool.description, tool.inputSchema.shape, tool.handler);
+    // registerTool (vs. the deprecated `tool(...)`) is the path that wires
+    // outputSchema + annotations into the protocol response. The handler
+    // is typed loosely via the factory signature; the SDK validates
+    // structuredContent against outputSchema at call time.
+    server.registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputSchema.shape,
+        outputSchema:
+          // outputSchema accepts either a ZodRawShape or a ZodObject. Our
+          // factories declare ZodTypeAny which covers both — the SDK does
+          // the right thing.
+          (tool.outputSchema as unknown as z.AnyZodObject).shape ?? tool.outputSchema,
+        annotations: tool.annotations,
+      },
+      tool.handler,
+    );
   }
 
   // Register resources

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,17 +18,16 @@ import { auditLinksPrompt } from "./prompts/audit-links.js";
 import { rotateAccessPrompt } from "./prompts/rotate-access.js";
 
 /**
- * Shared contract for the objects returned by tool factory functions. Each
- * tool exports the full `registerTool` config object so the SDK forwards
- * `outputSchema` and `annotations` into the MCP `tools/list` response —
- * downstream agents and TDQS scoring rely on those being present.
+ * Shape of the object every tool factory returns. Exported so the
+ * TDQS-coverage test can iterate the same canonical list without
+ * redeclaring the type.
  */
-type ToolFactory = (client: IQURLClient) => {
+export type ToolFactory = (client: IQURLClient) => {
   name: string;
   title: string;
   description: string;
   inputSchema: z.AnyZodObject;
-  outputSchema: z.ZodTypeAny;
+  outputSchema: z.AnyZodObject;
   annotations: ToolAnnotations;
   // Args vary per tool; exact signatures are validated by registerTool at each call site.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,42 +38,35 @@ type ToolFactory = (client: IQURLClient) => {
   }>;
 };
 
+export const toolFactories = [
+  createQurlTool,
+  resolveQurlTool,
+  listQurlsTool,
+  getQurlTool,
+  deleteQurlTool,
+  extendQurlTool,
+  updateQurlTool,
+  mintLinkTool,
+  batchCreateTool,
+] satisfies ToolFactory[];
+
 export function createServer(client: IQURLClient, version: string): McpServer {
   const server = new McpServer({
     name: "qurl",
     version,
   });
 
-  // Register tools
-  const toolFactories = [
-    createQurlTool,
-    resolveQurlTool,
-    listQurlsTool,
-    getQurlTool,
-    deleteQurlTool,
-    extendQurlTool,
-    updateQurlTool,
-    mintLinkTool,
-    batchCreateTool,
-  ] satisfies ToolFactory[];
-
   for (const factory of toolFactories) {
     const tool = factory(client);
-    // registerTool (vs. the deprecated `tool(...)`) is the path that wires
-    // outputSchema + annotations into the protocol response. The handler
-    // is typed loosely via the factory signature; the SDK validates
-    // structuredContent against outputSchema at call time.
+    // registerTool wires outputSchema + annotations into tools/list; pass
+    // .shape (ZodRawShape), not the ZodObject itself.
     server.registerTool(
       tool.name,
       {
         title: tool.title,
         description: tool.description,
         inputSchema: tool.inputSchema.shape,
-        outputSchema:
-          // outputSchema accepts either a ZodRawShape or a ZodObject. Our
-          // factories declare ZodTypeAny which covers both — the SDK does
-          // the right thing.
-          (tool.outputSchema as unknown as z.AnyZodObject).shape ?? tool.outputSchema,
+        outputSchema: tool.outputSchema.shape,
         annotations: tool.annotations,
       },
       tool.handler,

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -25,6 +25,10 @@ type ToolResult = {
  *   cannot model. True for everything here since we hit the qURL API.
  */
 export type ToolAnnotations = {
+  // `annotations.title` is *not* the same field as the top-level `title`
+  // on the tool object: the top-level one feeds `tools/list[*].title`,
+  // while this one is a behavioral hint surfaced separately by some
+  // hosts. Both are per the MCP spec; do not deduplicate.
   title?: string;
   readOnlyHint?: boolean;
   destructiveHint?: boolean;

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -39,10 +39,12 @@ export type ToolAnnotations = {
 // SDK's `structuredContent` is `Record<string, unknown>`; payloads are
 // typed against API response shapes. Single seam for the cast.
 // `T extends object` rules out primitives and `null` at compile time;
-// `{ length?: never }` rules out arrays (which would pass the SDK's
-// runtime type check but violate its JSON-object contract).
-// `Record<string, unknown>` would be tighter still, but client-defined
-// interfaces lack an index signature and don't satisfy it.
+// `{ length?: never }` rules out arrays. The constraint does *not*
+// reject `Map`/`Set`/`Date`/class instances with non-public state — in
+// practice every call site passes a plain object literal derived from
+// an API response, and asserting that contract structurally would need
+// a runtime check. Tighter `Record<string, unknown>` would be ideal,
+// but client-defined interfaces lack the implicit index signature.
 export function toStructuredContent<T extends object & { length?: never }>(
   value: T,
 ): Record<string, unknown> {

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -38,10 +38,12 @@ export type ToolAnnotations = {
 
 // SDK's `structuredContent` is `Record<string, unknown>`; payloads are
 // typed against API response shapes. Single seam for the cast.
-// `T extends object` rules out primitives and `null` at compile time —
-// `Record<string, unknown>` would be tighter, but client-defined
+// `T extends object` rules out primitives and `null` at compile time;
+// `{ length?: never }` rules out arrays (which would pass the SDK's
+// runtime type check but violate its JSON-object contract).
+// `Record<string, unknown>` would be tighter still, but client-defined
 // interfaces lack an index signature and don't satisfy it.
-export function toStructuredContent<T extends object>(
+export function toStructuredContent<T extends object & { length?: never }>(
   value: T,
 ): Record<string, unknown> {
   return value as unknown as Record<string, unknown>;

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -32,6 +32,12 @@ export type ToolAnnotations = {
   openWorldHint?: boolean;
 };
 
+// SDK's `structuredContent` is `Record<string, unknown>`; payloads are
+// typed against API response shapes. Single seam for the cast.
+export function toStructuredContent<T>(value: T): Record<string, unknown> {
+  return value as unknown as Record<string, unknown>;
+}
+
 /**
  * Wrap a tool handler so that a thrown `QURLAPIError` with
  * `code: "missing_api_key"` is converted into an `isError: true` content

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -3,11 +3,33 @@ import { QURLAPIError } from "../client.js";
 
 /**
  * Tool result shape that handlers return. Kept structural so we don't
- * take a hard dep on the MCP SDK's internal types.
+ * take a hard dep on the MCP SDK's internal types. `structuredContent`
+ * is what the SDK validates against `outputSchema` when one is declared
+ * on the tool; `content` carries the human-readable JSON for display.
  */
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
+};
+
+/**
+ * MCP tool behavioral annotations — hints to the host for safety / UX
+ * surfacing. Mirrors `ToolAnnotations` from the MCP SDK without taking
+ * a value-level dep on it (the SDK type lives behind a deep import).
+ *
+ * - `readOnlyHint` — tool does not modify server state (list, get, resolve).
+ * - `destructiveHint` — tool may delete or revoke (delete, optionally rotate).
+ * - `idempotentHint` — repeated calls with the same args yield the same effect.
+ * - `openWorldHint` — tool reaches an external service whose state the host
+ *   cannot model. True for everything here since we hit the qURL API.
+ */
+export type ToolAnnotations = {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
 };
 
 /**

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -38,7 +38,12 @@ export type ToolAnnotations = {
 
 // SDK's `structuredContent` is `Record<string, unknown>`; payloads are
 // typed against API response shapes. Single seam for the cast.
-export function toStructuredContent<T>(value: T): Record<string, unknown> {
+// `T extends object` rules out primitives and `null` at compile time —
+// `Record<string, unknown>` would be tighter, but client-defined
+// interfaces lack an index signature and don't satisfy it.
+export function toStructuredContent<T extends object>(
+  value: T,
+): Record<string, unknown> {
   return value as unknown as Record<string, unknown>;
 }
 

--- a/src/tools/batch-create.ts
+++ b/src/tools/batch-create.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { createQurlSchema } from "./create-qurl.js";
 import { withMissingApiKeyHandler } from "./_shared.js";
+import { batchCreateOutputSchema } from "./output-schemas.js";
 
 export const batchCreateSchema = z.object({
   items: z
@@ -14,11 +15,23 @@ export const batchCreateSchema = z.object({
 export function batchCreateTool(client: IQURLClient) {
   return {
     name: "batch_create_qurls",
+    title: "Batch Create qURLs",
     description:
-      "Create multiple qURLs in a single request. " +
-      "Returns per-item results including any errors for partial failures. " +
-      "The response sets isError=true when one or more items fail so agents can branch on partial failure without parsing the JSON.",
+      "Create up to 100 qURLs in a single request. The atomic-batch alternative to looping `create_qurl` — saves round trips and returns a single envelope of per-item results. " +
+      "Use this when you need to mint many qURLs at once (e.g. provisioning a vendor list, distributing per-customer share links). " +
+      "Use `create_qurl` for a single resource. " +
+      "**Response shape:** `{ succeeded: number, failed: number, results: BatchItemResult[], request_id?: string }`. Each `results[i]` carries `index` (matching the input position), `success`, plus either `qurl_link` + `resource_id` + `qurl_site` + `expires_at` (success) OR `error: { code, message }` (failure). " +
+      "**Partial failure signaling:** the handler sets `isError: true` on the tool response whenever `failed > 0`, so agents can branch without parsing JSON. The HTTP layer also returns 400 when every item fails — that's surfaced through the same shape (read `data.results[*].error`). " +
+      "**One-shot links:** like `create_qurl`, every `qurl_link` in the response is shown ONCE. Don't lose them.",
     inputSchema: batchCreateSchema,
+    outputSchema: batchCreateOutputSchema,
+    annotations: {
+      title: "Batch Create qURLs",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof batchCreateSchema>) => {
       const result = await client.batchCreate(input);
       // Defense-in-depth: batchCreate passes through HTTP 400, which is
@@ -55,6 +68,7 @@ export function batchCreateTool(client: IQURLClient) {
             text: JSON.stringify(payload),
           },
         ],
+        structuredContent: payload as unknown as Record<string, unknown>,
         isError: data.failed > 0,
       };
     }),

--- a/src/tools/batch-create.ts
+++ b/src/tools/batch-create.ts
@@ -60,9 +60,13 @@ export function batchCreateTool(client: IQURLClient) {
         };
       }
       const data = result.data;
+      // Spread request_id only when present so structuredContent doesn't
+      // expose an explicit `request_id: undefined` key to hosts that
+      // consume the raw object (JSON.stringify drops it; structured
+      // consumers don't).
       const payload = {
         ...data,
-        request_id: result.meta?.request_id,
+        ...(result.meta?.request_id && { request_id: result.meta.request_id }),
       };
       return {
         content: [

--- a/src/tools/batch-create.ts
+++ b/src/tools/batch-create.ts
@@ -64,10 +64,12 @@ export function batchCreateTool(client: IQURLClient) {
       // Spread request_id only when present so structuredContent doesn't
       // expose an explicit `request_id: undefined` key to hosts that
       // consume the raw object (JSON.stringify drops it; structured
-      // consumers don't).
+      // consumers don't). `!== undefined` rather than truthy so an
+      // empty-string request_id (shouldn't happen, but cheap to guard)
+      // doesn't silently drop.
       const payload = {
         ...data,
-        ...(result.meta?.request_id && { request_id: result.meta.request_id }),
+        ...(result.meta?.request_id !== undefined && { request_id: result.meta.request_id }),
       };
       return {
         content: [

--- a/src/tools/batch-create.ts
+++ b/src/tools/batch-create.ts
@@ -25,7 +25,8 @@ export function batchCreateTool(client: IQURLClient) {
     name: "batch_create_qurls",
     title: "Batch Create qURLs",
     description:
-      "Create up to 100 qURLs in a single request. The atomic-batch alternative to looping `create_qurl` — saves round trips and returns a single envelope of per-item results. " +
+      "Create up to 100 qURLs in a single request. The single-call alternative to looping `create_qurl` — saves round trips and returns a single envelope of per-item results. " +
+      "**Not transactional:** items succeed or fail independently (see `succeeded`/`failed` counts and per-item `error`). " +
       "Use this when you need to mint many qURLs at once (e.g. provisioning a vendor list, distributing per-customer share links). " +
       "Use `create_qurl` for a single resource. " +
       "**Response shape:** `{ succeeded: number, failed: number, results: BatchItemResult[], request_id?: string }`. Each `results[i]` carries `index` (matching the input position), `success`, plus either `qurl_link` + `resource_id` + `qurl_site` + `expires_at` (success) OR `error: { code, message }` (failure). " +

--- a/src/tools/batch-create.ts
+++ b/src/tools/batch-create.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { createQurlSchema } from "./create-qurl.js";
-import { withMissingApiKeyHandler } from "./_shared.js";
+import { toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
 import { batchCreateOutputSchema } from "./output-schemas.js";
 
 export const batchCreateSchema = z.object({
@@ -68,7 +68,7 @@ export function batchCreateTool(client: IQURLClient) {
             text: JSON.stringify(payload),
           },
         ],
-        structuredContent: payload as unknown as Record<string, unknown>,
+        structuredContent: toStructuredContent(payload),
         isError: data.failed > 0,
       };
     }),

--- a/src/tools/batch-create.ts
+++ b/src/tools/batch-create.ts
@@ -1,8 +1,16 @@
 import { z } from "zod";
-import type { IQURLClient } from "../client.js";
+import type { BatchCreateOutput, IQURLClient } from "../client.js";
 import { createQurlSchema } from "./create-qurl.js";
 import { toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
 import { batchCreateOutputSchema } from "./output-schemas.js";
+
+function isBatchPayload(value: unknown): value is BatchCreateOutput["data"] {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Partial<{ succeeded: unknown; failed: unknown; results: unknown }>;
+  return (
+    typeof v.succeeded === "number" && typeof v.failed === "number" && Array.isArray(v.results)
+  );
+}
 
 export const batchCreateSchema = z.object({
   items: z
@@ -40,13 +48,7 @@ export function batchCreateTool(client: IQURLClient) {
       // top-level malformed-request error), the downstream `failed > 0`
       // access would be meaningless — surface the raw response as an error
       // so agents get a real signal instead of silent mis-interpretation.
-      const data = result.data as Partial<typeof result.data> | undefined;
-      if (
-        !data ||
-        typeof data.failed !== "number" ||
-        typeof data.succeeded !== "number" ||
-        !Array.isArray(data.results)
-      ) {
+      if (!isBatchPayload(result.data)) {
         return {
           content: [
             {
@@ -57,6 +59,7 @@ export function batchCreateTool(client: IQURLClient) {
           isError: true,
         };
       }
+      const data = result.data;
       const payload = {
         ...data,
         request_id: result.meta?.request_id,

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { withMissingApiKeyHandler } from "./_shared.js";
+import { createQurlOutputSchema } from "./output-schemas.js";
 
 export const aiAgentPolicySchema = z.object({
   block_all: z.boolean().optional().describe("Block all recognized AI agents"),
@@ -74,10 +75,22 @@ export const createQurlSchema = z.object({
 export function createQurlTool(client: IQURLClient) {
   return {
     name: "create_qurl",
+    title: "Create qURL",
     description:
-      "Create a qURL - a secure, policy-bound link to a protected resource. " +
-      "The returned qurl_link is ephemeral (shown once) and should be shared immediately.",
+      "Create a new qURL — a policy-bound, expiring access link to a protected target URL. " +
+      "Use this when an agent needs to mint a fresh resource (e.g. share-once link, time-limited access). " +
+      "Use `mint_link` instead when you already have a resource and only need an additional access link. " +
+      "Use `batch_create_qurls` to create many in one call. " +
+      "Returns the new resource ID and a `qurl_link` that is shown ONCE and never returned by `get_qurl` or `list_qurls` — share it immediately.",
     inputSchema: createQurlSchema,
+    outputSchema: createQurlOutputSchema,
+    annotations: {
+      title: "Create qURL",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof createQurlSchema>) => {
       const result = await client.createQURL(input);
       return {
@@ -87,6 +100,7 @@ export function createQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
+        structuredContent: result.data as unknown as Record<string, unknown>,
       };
     }),
   };

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
-import { withMissingApiKeyHandler } from "./_shared.js";
+import { toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
 import { createQurlOutputSchema } from "./output-schemas.js";
 
 export const aiAgentPolicySchema = z.object({
@@ -100,7 +100,7 @@ export function createQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
-        structuredContent: result.data as unknown as Record<string, unknown>,
+        structuredContent: toStructuredContent(result.data),
       };
     }),
   };

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { IQURLClient } from "../client.js";
+import { type IQURLClient, QURLAPIError } from "../client.js";
 import { withMissingApiKeyHandler } from "./_shared.js";
 import { deleteQurlOutputSchema } from "./output-schemas.js";
 
@@ -37,7 +37,15 @@ export function deleteQurlTool(client: IQURLClient) {
       openWorldHint: true,
     },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof deleteQurlSchema>) => {
-      await client.deleteQURL(input.resource_id);
+      try {
+        await client.deleteQURL(input.resource_id);
+      } catch (err) {
+        // Re-delete of an already-revoked resource: the API returns 404,
+        // but the agent's intent ("this resource should not be live") is
+        // already satisfied. Swallow it so the tool is genuinely
+        // idempotent — matching `annotations.idempotentHint: true`.
+        if (!(err instanceof QURLAPIError) || err.statusCode !== 404) throw err;
+      }
       const payload = {
         resource_id: input.resource_id,
         revoked: true as const,

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -26,6 +26,7 @@ export function deleteQurlTool(client: IQURLClient) {
       "**This action is irreversible.** Use this when you want to cut off access entirely (compromised link, departed user, end-of-engagement). " +
       "Use `update_qurl` instead when you only need to shorten/extend the expiration, retag, or rename — those preserve the existing access tokens. " +
       "Use `extend_qurl` when you only need to push the expiration out. " +
+      "**Idempotent:** re-deletes return success even if the resource was already revoked or never existed — verify with `get_qurl` first if the ID came from user input. " +
       "Returns a confirmation payload. By default the resource is excluded from `list_qurls`; pass `status: \"revoked\"` to see it.",
     inputSchema: deleteQurlSchema,
     outputSchema: deleteQurlOutputSchema,

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -50,7 +50,7 @@ export function deleteQurlTool(client: IQURLClient) {
       const payload = {
         resource_id: input.resource_id,
         revoked: true as const,
-        message: `qURL ${input.resource_id} has been revoked.`,
+        message: `qURL ${input.resource_id} is revoked.`,
       };
       return {
         content: [

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -38,18 +38,23 @@ export function deleteQurlTool(client: IQURLClient) {
       openWorldHint: true,
     },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof deleteQurlSchema>) => {
+      let wasAlreadyRevoked = false;
       try {
         await client.deleteQURL(input.resource_id);
       } catch (err) {
-        // Re-delete of an already-revoked resource: the API returns 404,
-        // but the agent's intent ("this resource should not be live") is
-        // already satisfied. Swallow it so the tool is genuinely
-        // idempotent — matching `annotations.idempotentHint: true`.
+        // Re-delete of an already-revoked (or never-existed) resource:
+        // the API returns 404, but the agent's intent ("this resource
+        // should not be live") is already satisfied. Swallow the throw
+        // so the tool is genuinely idempotent, but expose
+        // `was_already_revoked: true` in the payload so defensive
+        // agents can branch when they care.
         if (!(err instanceof QURLAPIError) || err.statusCode !== 404) throw err;
+        wasAlreadyRevoked = true;
       }
       const payload = {
         resource_id: input.resource_id,
         revoked: true as const,
+        was_already_revoked: wasAlreadyRevoked,
         message: `qURL ${input.resource_id} is revoked.`,
       };
       return {

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { withMissingApiKeyHandler } from "./_shared.js";
+import { deleteQurlOutputSchema } from "./output-schemas.js";
 
 export const deleteQurlSchema = z.object({
   // DELETE only accepts r_ (resource) IDs per the API spec — unlike
@@ -19,17 +20,37 @@ export const deleteQurlSchema = z.object({
 export function deleteQurlTool(client: IQURLClient) {
   return {
     name: "delete_qurl",
-    description: "Revoke/delete a qURL. This immediately invalidates the link.",
+    title: "Delete qURL",
+    description:
+      "Permanently revoke a qURL — the link and every access token under it stop working immediately. " +
+      "**This action is irreversible.** Use this when you want to cut off access entirely (compromised link, departed user, end-of-engagement). " +
+      "Use `update_qurl` instead when you only need to shorten/extend the expiration, retag, or rename — those preserve the existing access tokens. " +
+      "Use `extend_qurl` when you only need to push the expiration out. " +
+      "Returns a confirmation payload — the resource will not appear in subsequent `list_qurls` calls (or returns with `status: \"revoked\"` depending on filter).",
     inputSchema: deleteQurlSchema,
+    outputSchema: deleteQurlOutputSchema,
+    annotations: {
+      title: "Delete qURL",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof deleteQurlSchema>) => {
       await client.deleteQURL(input.resource_id);
+      const payload = {
+        resource_id: input.resource_id,
+        revoked: true as const,
+        message: `qURL ${input.resource_id} has been revoked.`,
+      };
       return {
         content: [
           {
             type: "text" as const,
-            text: `qURL ${input.resource_id} has been revoked.`,
+            text: payload.message,
           },
         ],
+        structuredContent: payload,
       };
     }),
   };

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -48,6 +48,13 @@ export function deleteQurlTool(client: IQURLClient) {
         // so the tool is genuinely idempotent, but expose
         // `was_already_revoked: true` in the payload so defensive
         // agents can branch when they care.
+        //
+        // Intentionally checks status only, not `code`. A 404 with a
+        // non-JSON body (e.g. an HTML error page from a proxy in front
+        // of the API) lands here as `code: "parse_error"` — the
+        // resource still isn't live, so treating it as already-revoked
+        // is the right behavior; defensive agents see that via the
+        // `was_already_revoked` flag.
         if (!(err instanceof QURLAPIError) || err.statusCode !== 404) throw err;
         wasAlreadyRevoked = true;
       }

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -26,7 +26,7 @@ export function deleteQurlTool(client: IQURLClient) {
       "**This action is irreversible.** Use this when you want to cut off access entirely (compromised link, departed user, end-of-engagement). " +
       "Use `update_qurl` instead when you only need to shorten/extend the expiration, retag, or rename — those preserve the existing access tokens. " +
       "Use `extend_qurl` when you only need to push the expiration out. " +
-      "Returns a confirmation payload — the resource will not appear in subsequent `list_qurls` calls (or returns with `status: \"revoked\"` depending on filter).",
+      "Returns a confirmation payload. By default the resource is excluded from `list_qurls`; pass `status: \"revoked\"` to see it.",
     inputSchema: deleteQurlSchema,
     outputSchema: deleteQurlOutputSchema,
     annotations: {

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -26,7 +26,7 @@ export function deleteQurlTool(client: IQURLClient) {
       "**This action is irreversible.** Use this when you want to cut off access entirely (compromised link, departed user, end-of-engagement). " +
       "Use `update_qurl` instead when you only need to shorten/extend the expiration, retag, or rename — those preserve the existing access tokens. " +
       "Use `extend_qurl` when you only need to push the expiration out. " +
-      "**Idempotent:** re-deletes return success even if the resource was already revoked or never existed — verify with `get_qurl` first if the ID came from user input. " +
+      "**Idempotent:** re-deletes return success even if the resource was already revoked or never existed — verify with `get_qurl` first if the ID came from user input, or branch on the `was_already_revoked` flag in the response to distinguish the two cases. " +
       "Returns a confirmation payload. By default the resource is excluded from `list_qurls`; pass `status: \"revoked\"` to see it.",
     inputSchema: deleteQurlSchema,
     outputSchema: deleteQurlOutputSchema,

--- a/src/tools/extend-qurl.ts
+++ b/src/tools/extend-qurl.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
-import { resourceIdSchema, withMissingApiKeyHandler } from "./_shared.js";
+import { resourceIdSchema, toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
 import { extendQurlOutputSchema } from "./output-schemas.js";
 
 export const extendQurlSchema = z.object({
@@ -40,7 +40,7 @@ export function extendQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
-        structuredContent: result.data as unknown as Record<string, unknown>,
+        structuredContent: toStructuredContent(result.data),
       };
     }),
   };

--- a/src/tools/extend-qurl.ts
+++ b/src/tools/extend-qurl.ts
@@ -19,6 +19,7 @@ export function extendQurlTool(client: IQURLClient) {
       "Use `update_qurl` instead when you also need to change tags, description, or set an absolute `expires_at`. " +
       "Use `delete_qurl` when you want to cut off access entirely. " +
       "Accepts both `r_` and `q_` IDs (q_ is auto-resolved to its parent resource). " +
+      "**Not idempotent:** calling twice with the same `extend_by` extends the expiration twice. If you need an absolute target, use `update_qurl` with `expires_at` so retries on transient errors don't double-push. " +
       "Returns the updated resource with the new `expires_at` (same shape as `get_qurl`).",
     inputSchema: extendQurlSchema,
     outputSchema: extendQurlOutputSchema,

--- a/src/tools/extend-qurl.ts
+++ b/src/tools/extend-qurl.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { resourceIdSchema, withMissingApiKeyHandler } from "./_shared.js";
+import { extendQurlOutputSchema } from "./output-schemas.js";
 
 export const extendQurlSchema = z.object({
   resource_id: resourceIdSchema("extend"),
@@ -10,10 +11,24 @@ export const extendQurlSchema = z.object({
 export function extendQurlTool(client: IQURLClient) {
   return {
     name: "extend_qurl",
+    title: "Extend qURL Expiration",
     description:
-      "Extend the expiration of an active qURL. Accepts a resource ID (r_) or qURL display ID (q_). " +
-      "Shorthand for update_qurl with only extend_by — use update_qurl for richer updates (tags, description, expiration).",
+      "Push out the expiration of an active qURL by a relative duration. " +
+      "Convenience wrapper for the most common update — equivalent to `update_qurl({ resource_id, extend_by })`. " +
+      "Use this when the only change you need is more time on the clock. " +
+      "Use `update_qurl` instead when you also need to change tags, description, or set an absolute `expires_at`. " +
+      "Use `delete_qurl` when you want to cut off access entirely. " +
+      "Accepts both `r_` and `q_` IDs (q_ is auto-resolved to its parent resource). " +
+      "Returns the updated resource with the new `expires_at` (same shape as `get_qurl`).",
     inputSchema: extendQurlSchema,
+    outputSchema: extendQurlOutputSchema,
+    annotations: {
+      title: "Extend qURL Expiration",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof extendQurlSchema>) => {
       const result = await client.extendQURL(input.resource_id, {
         extend_by: input.extend_by,
@@ -25,6 +40,7 @@ export function extendQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
+        structuredContent: result.data as unknown as Record<string, unknown>,
       };
     }),
   };

--- a/src/tools/get-qurl.ts
+++ b/src/tools/get-qurl.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
-import { resourceIdSchema, withMissingApiKeyHandler } from "./_shared.js";
+import { resourceIdSchema, toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
 import { getQurlOutputSchema } from "./output-schemas.js";
 
 export const getQurlSchema = z.object({
@@ -35,7 +35,7 @@ export function getQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
-        structuredContent: result.data as unknown as Record<string, unknown>,
+        structuredContent: toStructuredContent(result.data),
       };
     }),
   };

--- a/src/tools/get-qurl.ts
+++ b/src/tools/get-qurl.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { resourceIdSchema, withMissingApiKeyHandler } from "./_shared.js";
+import { getQurlOutputSchema } from "./output-schemas.js";
 
 export const getQurlSchema = z.object({
   resource_id: resourceIdSchema("fetch"),
@@ -9,10 +10,22 @@ export const getQurlSchema = z.object({
 export function getQurlTool(client: IQURLClient) {
   return {
     name: "get_qurl",
+    title: "Get qURL",
     description:
-      "Get details of a qURL resource and its access tokens. " +
-      "Accepts either a resource ID (r_ prefix) or a qURL display ID (q_ prefix).",
+      "Fetch a single qURL resource by ID and return its current state plus all access tokens. " +
+      "Use this when you have a specific resource ID (r_ prefix) or qURL display ID (q_ prefix) — q_ IDs are auto-resolved to their parent resource. " +
+      "Use `list_qurls` instead when you need to discover qURLs by status, date range, or search query. " +
+      "Use `resolve_qurl` instead when you have an end-user access token (at_ prefix) and need to redeem it for the underlying URL. " +
+      "Returns the resource shape with embedded `qurls[]` (per-token state); the one-shot `qurl_link` from creation is never returned here.",
     inputSchema: getQurlSchema,
+    outputSchema: getQurlOutputSchema,
+    annotations: {
+      title: "Get qURL",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof getQurlSchema>) => {
       const result = await client.getQURL(input.resource_id);
       return {
@@ -22,6 +35,7 @@ export function getQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
+        structuredContent: result.data as unknown as Record<string, unknown>,
       };
     }),
   };

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
-import { withMissingApiKeyHandler } from "./_shared.js";
+import { toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
 import { listQurlsOutputSchema } from "./output-schemas.js";
 
 export const listQurlsSchema = z.object({
@@ -73,7 +73,7 @@ export function listQurlsTool(client: IQURLClient) {
             text: JSON.stringify(result),
           },
         ],
-        structuredContent: result as unknown as Record<string, unknown>,
+        structuredContent: toStructuredContent(result),
       };
     }),
   };

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { withMissingApiKeyHandler } from "./_shared.js";
+import { listQurlsOutputSchema } from "./output-schemas.js";
 
 export const listQurlsSchema = z.object({
   limit: z
@@ -43,9 +44,25 @@ export const listQurlsSchema = z.object({
 export function listQurlsTool(client: IQURLClient) {
   return {
     name: "list_qurls",
+    title: "List qURLs",
     description:
-      "List qURLs with optional filtering by status, date ranges, and search query.",
+      "List qURL resources, paginated and optionally filtered. " +
+      "Use this to discover qURLs by status (`active`, `revoked`), date range (created_*, expires_*), search text (`q`), or sort order. " +
+      "Use `get_qurl` instead when you already have a specific resource ID. " +
+      "**Pagination:** default page size is 20 (configurable via `limit` up to 100). " +
+      "When the response sets `meta.has_more: true`, pass `meta.next_cursor` as the `cursor` argument on a subsequent call to fetch the next page. " +
+      "**Sorting:** use `sort` like `created_at:desc` (default) or `expires_at:asc`. " +
+      "**Response shape:** `{ data: QURL[], meta: { has_more, next_cursor?, page_size?, request_id? } }` — `data[]` items are the same stable resource shape returned by `get_qurl`, with no per-token detail (call `get_qurl` for `qurls[]`). " +
+      'Example: `list_qurls({ status: "active", sort: "expires_at:asc", limit: 10 })`.',
     inputSchema: listQurlsSchema,
+    outputSchema: listQurlsOutputSchema,
+    annotations: {
+      title: "List qURLs",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof listQurlsSchema>) => {
       const result = await client.listQURLs(input);
       return {
@@ -56,6 +73,7 @@ export function listQurlsTool(client: IQURLClient) {
             text: JSON.stringify(result),
           },
         ],
+        structuredContent: result as unknown as Record<string, unknown>,
       };
     }),
   };

--- a/src/tools/mint-link.ts
+++ b/src/tools/mint-link.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { accessPolicySchema } from "./create-qurl.js";
 import { resourceIdSchema, withMissingApiKeyHandler, zodErrorToToolResult } from "./_shared.js";
+import { mintLinkOutputSchema } from "./output-schemas.js";
 
 export const mintLinkBaseSchema = z.object({
   resource_id: resourceIdSchema("mint a new access link for"),
@@ -40,12 +41,24 @@ export const mintLinkSchema = mintLinkBaseSchema.refine(
 export function mintLinkTool(client: IQURLClient) {
   return {
     name: "mint_link",
+    title: "Mint Access Link",
     description:
-      "Mint a new access link for an existing qURL resource. " +
-      "Accepts either a resource ID (r_ prefix) or qURL display ID (q_ prefix). " +
-      "Use this to generate additional access links without creating a new resource. " +
-      "Do not provide both expires_in and expires_at.",
+      "Mint a fresh single-use access link for an existing qURL resource — same one-shot semantics as `create_qurl.qurl_link`. " +
+      "Use this to issue additional access links to a resource without creating a brand-new qURL (e.g. a second recipient, a replacement after the original was lost). " +
+      "Use `create_qurl` instead when you want a brand-new resource with its own target_url and policy. " +
+      "Use `update_qurl` when you only want to change expiration/tags/description on the existing resource. " +
+      "Accepts both `r_` and `q_` IDs. " +
+      "**Constraints:** `expires_in` and `expires_at` are mutually exclusive (handler returns an `isError: true` content block before any API call if both are set). " +
+      "**Output:** the new `qurl_link` is shown ONCE — no subsequent call returns it. Save it immediately.",
     inputSchema: mintLinkBaseSchema,
+    outputSchema: mintLinkOutputSchema,
+    annotations: {
+      title: "Mint Access Link",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (raw: z.infer<typeof mintLinkBaseSchema>) => {
       const parsed = mintLinkSchema.safeParse(raw);
       if (!parsed.success) return zodErrorToToolResult(parsed.error);
@@ -61,6 +74,7 @@ export function mintLinkTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
+        structuredContent: result.data as unknown as Record<string, unknown>,
       };
     }),
   };

--- a/src/tools/mint-link.ts
+++ b/src/tools/mint-link.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { accessPolicySchema } from "./create-qurl.js";
-import { resourceIdSchema, withMissingApiKeyHandler, zodErrorToToolResult } from "./_shared.js";
+import {
+  resourceIdSchema,
+  toStructuredContent,
+  withMissingApiKeyHandler,
+  zodErrorToToolResult,
+} from "./_shared.js";
 import { mintLinkOutputSchema } from "./output-schemas.js";
 
 export const mintLinkBaseSchema = z.object({
@@ -74,7 +79,7 @@ export function mintLinkTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
-        structuredContent: result.data as unknown as Record<string, unknown>,
+        structuredContent: toStructuredContent(result.data),
       };
     }),
   };

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -1,0 +1,155 @@
+import { z } from "zod";
+
+/**
+ * Output schemas for MCP tools.
+ *
+ * Each schema describes the **payload** a tool's `structuredContent` carries —
+ * the inner data shape, not the API envelope. The text content of every tool
+ * response already serializes this same payload, so structuredContent and
+ * text describe the same value in two formats.
+ *
+ * The MCP SDK validates `structuredContent` against the `outputSchema` we
+ * register on each tool. Hosts use the schema to render structured responses,
+ * and downstream agents use it to plan their call shape — so keeping these
+ * aligned with the API spec at `api-spec/qurls.yaml` is part of the API spec
+ * drift workflow.
+ */
+
+const accessPolicy = z
+  .object({
+    ip_allowlist: z.array(z.string()).optional(),
+    ip_denylist: z.array(z.string()).optional(),
+    geo_allowlist: z.array(z.string()).optional(),
+    geo_denylist: z.array(z.string()).optional(),
+    user_agent_allow_regex: z.string().optional(),
+    user_agent_deny_regex: z.string().optional(),
+    ai_agent_policy: z
+      .object({
+        block_all: z.boolean().optional(),
+        deny_categories: z.array(z.string()).optional(),
+        allow_categories: z.array(z.string()).optional(),
+      })
+      .optional(),
+  })
+  .describe("Access control policy snapshot for this token");
+
+const accessTokenSchema = z
+  .object({
+    qurl_id: z.string(),
+    label: z.string().optional(),
+    status: z
+      .enum(["active", "consumed", "expired", "revoked"])
+      .describe("Per-token status (wider than resource status — tokens may be consumed/expired independently)"),
+    one_time_use: z.boolean(),
+    max_sessions: z.number(),
+    session_duration: z.number().describe("Seconds of access granted after a successful resolve"),
+    use_count: z.number(),
+    qurl_site: z.string().optional(),
+    access_policy: accessPolicy.optional(),
+    created_at: z.string(),
+    expires_at: z.string(),
+  })
+  .describe("Single access token belonging to a qURL resource");
+
+/** Stable QURL resource shape returned by get/list/update/extend. */
+export const qurlSchema = z.object({
+  resource_id: z.string().describe("Stable resource identifier (r_ prefix)"),
+  qurl_site: z.string().optional(),
+  target_url: z.string().describe("Underlying URL the qURL protects"),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  expires_at: z.string(),
+  created_at: z.string(),
+  status: z.enum(["active", "revoked"]),
+  custom_domain: z.string().nullable().optional(),
+  qurl_count: z.number().optional().describe("Number of access tokens minted for this resource"),
+  qurls: z.array(accessTokenSchema).optional(),
+});
+
+/** Ephemeral create-time payload — note `qurl_link` is one-shot. */
+export const createQurlOutputSchema = z.object({
+  qurl_id: z.string().describe("Display-friendly qURL ID (q_ prefix)"),
+  resource_id: z.string().describe("Stable resource identifier (r_ prefix)"),
+  qurl_link: z
+    .string()
+    .describe("Single-use access link — shown ONCE on creation, never returned again. Share immediately."),
+  qurl_site: z.string(),
+  expires_at: z.string(),
+  label: z.string().optional(),
+});
+
+export const getQurlOutputSchema = qurlSchema;
+export const updateQurlOutputSchema = qurlSchema;
+export const extendQurlOutputSchema = qurlSchema;
+
+/**
+ * Paginated list response. When `meta.has_more` is true, pass
+ * `meta.next_cursor` as the `cursor` argument on the next call.
+ */
+export const listQurlsOutputSchema = z.object({
+  data: z.array(qurlSchema),
+  meta: z.object({
+    next_cursor: z.string().optional().describe("Pass to a subsequent list_qurls call to fetch the next page"),
+    has_more: z.boolean().describe("True if more pages are available beyond this response"),
+    page_size: z.number().optional(),
+    request_id: z.string().optional(),
+  }),
+});
+
+/** Resolve response: target_url + the access_grant that opens the firewall. */
+export const resolveQurlOutputSchema = z.object({
+  target_url: z.string().describe("Underlying URL revealed by the resolve"),
+  resource_id: z.string(),
+  access_grant: z
+    .object({
+      expires_in: z
+        .number()
+        .describe("Seconds the firewall will permit access from `src_ip` before re-resolution is required"),
+      granted_at: z.string(),
+      src_ip: z.string().describe("Caller IP that the access grant is bound to"),
+    })
+    .describe("Time-bound, IP-bound access grant — required for the qURL firewall to permit the next request"),
+});
+
+/** Mint response: a fresh `qurl_link` for an existing resource. One-shot, like create_qurl. */
+export const mintLinkOutputSchema = z.object({
+  qurl_link: z.string().describe("Newly minted single-use access link (one-shot, like create_qurl)"),
+  expires_at: z.string(),
+});
+
+const batchItemResultSchema = z
+  .object({
+    index: z.number().describe("Index of the corresponding item in the input `items` array"),
+    success: z.boolean(),
+    resource_id: z.string().optional(),
+    qurl_link: z.string().optional().describe("One-shot access link — populated only when `success: true`"),
+    qurl_site: z.string().optional(),
+    expires_at: z.string().optional(),
+    error: z
+      .object({
+        code: z.string(),
+        message: z.string(),
+      })
+      .optional()
+      .describe("Per-item error — populated only when `success: false`"),
+  })
+  .describe("Per-item result. `qurl_link` and `error` are mutually exclusive.");
+
+/**
+ * Batch creation response. The handler sets `isError: true` when `failed > 0`
+ * so agents can branch on partial failure without parsing JSON. `request_id`
+ * is hoisted from response metadata for support correlation.
+ */
+export const batchCreateOutputSchema = z.object({
+  succeeded: z.number(),
+  failed: z.number(),
+  results: z.array(batchItemResultSchema),
+  request_id: z.string().optional(),
+});
+
+/** Delete confirmation. The qURL is immediately revoked. */
+export const deleteQurlOutputSchema = z.object({
+  resource_id: z.string(),
+  revoked: z.literal(true),
+  message: z.string().describe("Human-readable confirmation message"),
+});

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -149,6 +149,10 @@ const batchItemResultSchema = z
  * Batch creation response. The handler sets `isError: true` when `failed > 0`
  * so agents can branch on partial failure without parsing JSON. `request_id`
  * is hoisted from response metadata for support correlation.
+ *
+ * Shape diverges from `BatchCreateOutput` (`{ data, meta }` envelope) by
+ * design: agents read a single flat object, and `output-schemas.types.test.ts`
+ * intentionally omits a round-trip assertion for this schema.
  */
 export const batchCreateOutputSchema = z.object({
   succeeded: z.number(),

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -127,23 +127,31 @@ export const mintLinkOutputSchema = z.object({
   expires_at: z.string(),
 });
 
+// Discriminated on `success` so the schema enforces the API's
+// mutual-exclusivity contract — a host or planner generating UI from
+// the schema will only show success-fields under `success: true` and
+// the `error` block under `success: false`, never both.
+const batchItemSuccessSchema = z.object({
+  index: z.number().describe("Index of the corresponding item in the input `items` array"),
+  success: z.literal(true),
+  resource_id: z.string(),
+  qurl_link: z.string().describe("One-shot access link — shown ONCE on creation"),
+  qurl_site: z.string(),
+  expires_at: z.string(),
+});
+
+const batchItemFailureSchema = z.object({
+  index: z.number().describe("Index of the corresponding item in the input `items` array"),
+  success: z.literal(false),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
 const batchItemResultSchema = z
-  .object({
-    index: z.number().describe("Index of the corresponding item in the input `items` array"),
-    success: z.boolean(),
-    resource_id: z.string().optional(),
-    qurl_link: z.string().optional().describe("One-shot access link — populated only when `success: true`"),
-    qurl_site: z.string().optional(),
-    expires_at: z.string().optional(),
-    error: z
-      .object({
-        code: z.string(),
-        message: z.string(),
-      })
-      .optional()
-      .describe("Per-item error — populated only when `success: false`"),
-  })
-  .describe("Per-item result. `qurl_link` and `error` are mutually exclusive.");
+  .discriminatedUnion("success", [batchItemSuccessSchema, batchItemFailureSchema])
+  .describe("Per-item result. Discriminated on `success`.");
 
 /**
  * Batch creation response. The handler sets `isError: true` when `failed > 0`
@@ -161,9 +169,15 @@ export const batchCreateOutputSchema = z.object({
   request_id: z.string().optional(),
 });
 
-/** Delete confirmation. The qURL is immediately revoked. */
+/** Delete confirmation. The qURL is in a revoked state after this call. */
 export const deleteQurlOutputSchema = z.object({
   resource_id: z.string(),
   revoked: z.literal(true),
+  was_already_revoked: z
+    .boolean()
+    .describe(
+      "True when the API responded 404 (resource was already revoked or never existed). " +
+        "Agents that need to distinguish 'I revoked it' from 'it was already gone' should branch on this.",
+    ),
   message: z.string().describe("Human-readable confirmation message"),
 });

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -150,9 +150,9 @@ const batchItemResultSchema = z
  * so agents can branch on partial failure without parsing JSON. `request_id`
  * is hoisted from response metadata for support correlation.
  *
- * Shape diverges from `BatchCreateOutput` (`{ data, meta }` envelope) by
- * design: agents read a single flat object, and `output-schemas.types.test.ts`
- * intentionally omits a round-trip assertion for this schema.
+ * Schema flattens the `{ data, meta }` envelope on `BatchCreateOutput` —
+ * `output-schemas.types.test.ts` asserts the flattened shape against the
+ * client interface so drift on either side fails compilation.
  */
 export const batchCreateOutputSchema = z.object({
   succeeded: z.number(),

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -13,6 +13,14 @@ import { z } from "zod";
  * and downstream agents use it to plan their call shape — so keeping these
  * aligned with the API spec at `api-spec/qurls.yaml` is part of the API spec
  * drift workflow.
+ *
+ * Why URLs and timestamps are plain `z.string()` (not `.url()`/`.datetime()`):
+ * these schemas validate API *responses*, not user input. A tighter local
+ * validator that disagrees with the server (e.g. an `https://` redirect that
+ * Zod's URL parser rejects, or a timestamp Go formats slightly differently
+ * from RFC 3339 strict mode) would turn a valid API response into a tool
+ * error for no benefit. We trust the server on shape and use `.string()` as
+ * an existence/typeof check.
  */
 
 const accessPolicy = z
@@ -60,6 +68,8 @@ export const qurlSchema = z.object({
   tags: z.array(z.string()).optional(),
   expires_at: z.string(),
   created_at: z.string(),
+  // Enum sourced from api-spec/qurls.yaml; if the API adds a value, the
+  // spec-drift workflow catches it before this validation hard-fails.
   status: z.enum(["active", "revoked"]),
   custom_domain: z.string().nullable().optional(),
   qurl_count: z.number().optional().describe("Number of access tokens minted for this resource"),

--- a/src/tools/resolve-qurl.ts
+++ b/src/tools/resolve-qurl.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
-import { withMissingApiKeyHandler } from "./_shared.js";
+import { toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
 import { resolveQurlOutputSchema } from "./output-schemas.js";
 
 export const resolveQurlSchema = z.object({
@@ -37,7 +37,7 @@ export function resolveQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
-        structuredContent: result.data as unknown as Record<string, unknown>,
+        structuredContent: toStructuredContent(result.data),
       };
     }),
   };

--- a/src/tools/resolve-qurl.ts
+++ b/src/tools/resolve-qurl.ts
@@ -18,7 +18,8 @@ export function resolveQurlTool(client: IQURLClient) {
       "Redeem a qURL access token (the `at_` prefix you pulled out of a `qurl_link`) to reveal the underlying URL and open a time-bound, IP-bound firewall grant. " +
       "Use this when an agent has been handed an access token and needs to fetch the protected resource — after a successful resolve, requests from `access_grant.src_ip` will be permitted to the `target_url` for `access_grant.expires_in` seconds. " +
       "Use `get_qurl` instead when you have a resource ID (`r_`) or qURL display ID (`q_`) and want admin-side details rather than end-user redemption. " +
-      "**Side-effects:** consumes one use on `one_time_use` tokens, decrements `max_sessions`, and may trip access policies (IP/geo/UA/AI-agent denylists). Repeated calls within the grant window are idempotent for tokens that aren't one-time-use, but consume on tokens that are.",
+      "**Side-effects:** consumes one use on `one_time_use` tokens, decrements `max_sessions`, and may trip access policies (IP/geo/UA/AI-agent denylists). " +
+      "**`idempotentHint: false`** because one-time-use tokens consume on each call; for non-one-time tokens within an active grant window, repeats are effectively no-ops, but the conservative annotation reflects worst-case behavior.",
     inputSchema: resolveQurlSchema,
     outputSchema: resolveQurlOutputSchema,
     annotations: {

--- a/src/tools/resolve-qurl.ts
+++ b/src/tools/resolve-qurl.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { withMissingApiKeyHandler } from "./_shared.js";
+import { resolveQurlOutputSchema } from "./output-schemas.js";
 
 export const resolveQurlSchema = z.object({
   access_token: z
@@ -12,11 +13,21 @@ export const resolveQurlSchema = z.object({
 export function resolveQurlTool(client: IQURLClient) {
   return {
     name: "resolve_qurl",
+    title: "Resolve qURL Access Token",
     description:
-      "Resolve a qURL access token to get the target URL and open firewall access. " +
-      "After resolution, the target URL is accessible from your IP for the duration " +
-      "specified in access_grant.expires_in seconds.",
+      "Redeem a qURL access token (the `at_` prefix you pulled out of a `qurl_link`) to reveal the underlying URL and open a time-bound, IP-bound firewall grant. " +
+      "Use this when an agent has been handed an access token and needs to fetch the protected resource — after a successful resolve, requests from `access_grant.src_ip` will be permitted to the `target_url` for `access_grant.expires_in` seconds. " +
+      "Use `get_qurl` instead when you have a resource ID (`r_`) or qURL display ID (`q_`) and want admin-side details rather than end-user redemption. " +
+      "**Side-effects:** consumes one use on `one_time_use` tokens, decrements `max_sessions`, and may trip access policies (IP/geo/UA/AI-agent denylists). Repeated calls within the grant window are idempotent for tokens that aren't one-time-use, but consume on tokens that are.",
     inputSchema: resolveQurlSchema,
+    outputSchema: resolveQurlOutputSchema,
+    annotations: {
+      title: "Resolve qURL Access Token",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (input: z.infer<typeof resolveQurlSchema>) => {
       const result = await client.resolveQURL(input);
       return {
@@ -26,6 +37,7 @@ export function resolveQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
+        structuredContent: result.data as unknown as Record<string, unknown>,
       };
     }),
   };

--- a/src/tools/update-qurl.ts
+++ b/src/tools/update-qurl.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
 import { resourceIdSchema, withMissingApiKeyHandler, zodErrorToToolResult } from "./_shared.js";
+import { updateQurlOutputSchema } from "./output-schemas.js";
 
 // Tags must match the API constraints: 1-50 chars, start with alphanumeric,
 // allow alphanumerics/spaces/underscores/hyphens. Max 10 tags per resource.
@@ -53,12 +54,26 @@ export const updateQurlSchema = updateQurlBaseSchema
 export function updateQurlTool(client: IQURLClient) {
   return {
     name: "update_qurl",
+    title: "Update qURL",
     description:
-      "Update a qURL - extend expiration, set an absolute expiry, update tags, or change the description. " +
-      "Accepts either a resource ID (r_ prefix) or qURL display ID (q_ prefix). " +
-      "Do not provide both extend_by and expires_at. At least one update field is required.",
+      "Update a qURL's expiration, tags, or description. The richer alternative to `extend_qurl` — use `update_qurl` whenever you need anything beyond a relative time push. " +
+      "Accepts both `r_` and `q_` IDs (q_ is auto-resolved). " +
+      "**Constraints:** `extend_by` and `expires_at` are mutually exclusive; at least one update field (`extend_by`, `expires_at`, `tags`, `description`) must be set. " +
+      "**Clearing fields:** pass `description: \"\"` or `tags: []` to clear those fields explicitly. " +
+      "Use `extend_qurl` when the only change is a relative time push. " +
+      "Use `delete_qurl` when you want to revoke entirely. " +
+      "**Errors:** if the input fails schema refinements (both extend_by + expires_at, or no fields set), the handler returns an `isError: true` content block before any API call. Other API errors throw with the API's `code`/`statusCode`. " +
+      "Returns the updated resource (same shape as `get_qurl`).",
     // Base shape for MCP tool registration; refinements run in the handler
     inputSchema: updateQurlBaseSchema,
+    outputSchema: updateQurlOutputSchema,
+    annotations: {
+      title: "Update qURL",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     handler: withMissingApiKeyHandler(async (raw: z.infer<typeof updateQurlBaseSchema>) => {
       const parsed = updateQurlSchema.safeParse(raw);
       if (!parsed.success) return zodErrorToToolResult(parsed.error);
@@ -71,6 +86,7 @@ export function updateQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
+        structuredContent: result.data as unknown as Record<string, unknown>,
       };
     }),
   };

--- a/src/tools/update-qurl.ts
+++ b/src/tools/update-qurl.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import type { IQURLClient } from "../client.js";
-import { resourceIdSchema, withMissingApiKeyHandler, zodErrorToToolResult } from "./_shared.js";
+import {
+  resourceIdSchema,
+  toStructuredContent,
+  withMissingApiKeyHandler,
+  zodErrorToToolResult,
+} from "./_shared.js";
 import { updateQurlOutputSchema } from "./output-schemas.js";
 
 // Tags must match the API constraints: 1-50 chars, start with alphanumeric,
@@ -86,7 +91,7 @@ export function updateQurlTool(client: IQURLClient) {
             text: JSON.stringify(result.data),
           },
         ],
-        structuredContent: result.data as unknown as Record<string, unknown>,
+        structuredContent: toStructuredContent(result.data),
       };
     }),
   };


### PR DESCRIPTION
## Summary

Improves Glama TDQS (Tool Definition Quality Score) — currently **3.6 / 5** with the rubric flagging missing output schemas, missing behavioral annotations, and thin descriptions across the surface — by addressing every per-tool gap the rubric called out.

## What changes per tool (all 9)

- **`title`** field (separate from `name`) for friendly host display
- **`outputSchema`** declared via Zod and forwarded into `tools/list` (the SDK validates `structuredContent` against it at call time)
- **`annotations`** per the MCP spec — `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. Examples:
  - `list_qurls`, `get_qurl` → `readOnlyHint: true`
  - `delete_qurl` → `destructiveHint: true`, `idempotentHint: true`
  - All 9 → `openWorldHint: true` (talks to the qURL API)
- **Descriptions expanded** with: clear one-liner of intent, when-to-use vs sibling tools, return-shape sketch, side-effects, pagination/cursor notes (`list_qurls`)
- **Handlers return `structuredContent`** alongside the existing text content — same payload in both formats

## Server-level

- `src/server.ts` migrated from the deprecated `tool()` to **`registerTool()`** with the config-object pattern. `registerTool` is the path that forwards `outputSchema`/`annotations` into the protocol response; `tool()` would silently drop both.
- New `src/tools/output-schemas.ts` collects Zod schemas mirroring the `client.ts` response shapes — kept in one file so the API spec drift workflow has a single update point.
- `ToolAnnotations` type added to `src/tools/_shared.ts` so factories can type-check their annotation shape without a deep import from the SDK.

## Behavior changes (release-notes worthy)

- **`delete_qurl` is now genuinely idempotent.** Previously, calling `delete_qurl` on an already-revoked or non-existent resource raised the API's 404 to the agent. The handler now swallows the 404 and returns `{ resource_id, revoked: true, was_already_revoked: true, message }` — matching the tool's `annotations.idempotentHint: true` declaration. The new `was_already_revoked` flag in `structuredContent` lets defensive agents distinguish *"I revoked it just now"* from *"the API said 404, treated as no-op"*. Trade-off: the tool can no longer distinguish *"already revoked"* from *"never existed"* by exception alone — both report `revoked: true` (with `was_already_revoked: true`). Other API errors (403, 5xx, etc.) still propagate. Covered by new tests in `delete-qurl.test.ts`.
- **`delete_qurl` confirmation message wording updated.** `"qURL r_xxx has been revoked."` → `"qURL r_xxx is revoked."` — the new wording asserts state rather than action, which is more accurate on the idempotent path. Hosts or transcripts that pattern-match the old string will need a small update.
- **`BatchItemResult` is now a discriminated union on `success`** in `client.ts`, matching the API's mutual-exclusivity contract. Consumers narrowing on `success` get type-safe access to the success-only fields (`qurl_link`, etc.) and the failure-only `error` block. The accompanying `batchItemResultSchema` uses `z.discriminatedUnion("success", ...)` so host UIs generated from the schema render only the relevant branch. Existing callers that didn't narrow continue to work; ones that read both branches at once need to add a discriminator check.

## Additive only on input/text

Input schemas, tool names, and the **shape** of tool responses are unchanged. `structuredContent` is purely additive — older MCP hosts that ignore it see the exact same payload they did before. Goes out as `feat:`, will bump 0.3.1 → 0.4.0 (pre-1.0 minor convention).

## Verified

- `npm run build && npm run lint && npm test` — **366/366 pass** (276 baseline + 90 new tests covering output schemas, annotations, structuredContent round-trip, type-equality, disambiguation guidance, the 404-swallow paths, and `was_already_revoked` flag)
- Rebuilt the Docker image and ran `tools/list` against it: every one of the 9 tools now exposes `title`, `outputSchema`, and `annotations` in the response.

```
9 tools
  ✓ create_qurl               title=True outputSchema=True annotations=True
  ✓ resolve_qurl              title=True outputSchema=True annotations=True
  ✓ list_qurls                title=True outputSchema=True annotations=True
  ✓ get_qurl                  title=True outputSchema=True annotations=True
  ✓ delete_qurl               title=True outputSchema=True annotations=True
  ✓ extend_qurl               title=True outputSchema=True annotations=True
  ✓ update_qurl               title=True outputSchema=True annotations=True
  ✓ mint_link                 title=True outputSchema=True annotations=True
  ✓ batch_create_qurls        title=True outputSchema=True annotations=True
```

## Expected score impact

Glama's pre-PR coherence summary: *"qURL server provides a coherent set of tools for managing secure links. Minor issues include a naming inconsistency with `mint_link` and partial overlap between extend_qurl and update_qurl."* Per-tool: *"Given 9 parameters, no output schema, and no annotations, the description is insufficient"* (list_qurls), *"Complex tool with 8 params and nested objects, but no output schema or behavioral details"* (batch_create_qurls), *"description lacks explicit when/when-not to use this tool vs alternatives"* (delete_qurl, get_qurl).

Tier 1 alone (this PR) targets a lift from **3.6 → ~4.3+**. Naming consistency (`mint_link`, `batch_create_qurls` plural) is intentionally deferred — it's breaking and warrants its own coordinated `feat!:`.

## Test plan

- [x] Build, lint, test green locally (366/366)
- [x] Docker image still passes the full end-to-end probe
- [x] Each tool now exposes `title` + `outputSchema` + `annotations` in `tools/list`
- [x] CI green across CI / CodeQL / Dependency Review / Secrets Scan / Dependency Age Check
- [x] Claude Code Review converged across 12 rounds (LGTM)
- [ ] Glama rescan picks up the new schemas and bumps the score

## Follow-ups (separate issues)

Tracked in #83:
- Verify `delete_qurl` 404 swallow doesn't mask permission denials (cross-tenant 404 vs 403)
- Smoke-test `update_qurl extend_by: \"24h\"` against the live API
- Soften `qurlSchema.status` enum once the API status taxonomy stabilizes
- Audit description verbosity against host UIs (Claude Desktop, Cursor, Glama)
- Verify `update_qurl` clear-field semantics (description: \"\" / tags: [])
- Add `preserve_host` to `client.ts.QURL` and `qurlSchema` (pre-existing drift surfaced by the new strict schemas)

Naming consistency PR (separate, breaking): rename `mint_link` → `mint_qurl_link`, `batch_create_qurls` → `batch_create_qurl` — would land as `feat!:` 0.5.0 with deprecated aliases for one cycle.