### PR TITLE
fix(client): add preserve_host to QURL + qurlSchema

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -36,6 +36,7 @@ export interface QURL {
   created_at: string;
   status: "active" | "revoked";
   custom_domain?: string | null;
+  preserve_host?: boolean;
   qurl_count?: number;
   qurls?: AccessToken[];
 }

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -72,6 +72,13 @@ export const qurlSchema = z.object({
   // spec-drift workflow catches it before this validation hard-fails.
   status: z.enum(["active", "revoked"]),
   custom_domain: z.string().nullable().optional(),
+  preserve_host: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, the original Host header is preserved when proxying via the custom domain. " +
+        "Only meaningful when custom_domain is set; defaults to false on the API side.",
+    ),
   qurl_count: z.number().optional().describe("Number of access tokens minted for this resource"),
   qurls: z.array(accessTokenSchema).optional(),
 });


### PR DESCRIPTION
## Summary

Closes item 7 of #83 — pre-existing drift between the API spec and our types, surfaced by PR #82's new strict-shape Zod schemas.

`api-spec/qurls.yaml:2351-2354` lists `preserve_host` (boolean) on `ResourceData`. It was missing from both `client.ts.QURL` and `qurlSchema` in `output-schemas.ts`. After #82, a server that returns `preserve_host` would have it silently stripped from `structuredContent` (Zod's default strip mode).

## Changes

- `client.ts.QURL` — add `preserve_host?: boolean`
- `output-schemas.ts.qurlSchema` — add the matching `z.boolean().optional()` with a descriptive `.describe()` pointing at the field's semantics (proxy host header preservation, only meaningful with `custom_domain`).

The `expectTypeOf` test in `output-schemas.types.test.ts` now enforces alignment between the two, so future drift on this field will fail compilation.

## Test plan

- [x] `npm run build && npm run lint && npm test` — 366/366 pass
- [ ] CI green
- [ ] Confirm against a `get_qurl` response carrying a `custom_domain` resource that the field reaches us

🤖 Generated with [Claude Code](https://claude.com/claude-code)