### PR TITLE
chore(ci): republish to MCP Registry at 0.3.4 + auto-publish workflow

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -13,21 +13,28 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install mcp-publisher
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           version="v1.7.2"
-          url="https://github.com/modelcontextprotocol/registry/releases/download/${version}/mcp-publisher_linux_amd64.tar.gz"
+          tarball="mcp-publisher_linux_amd64.tar.gz"
+          # Pinned sha256 from upstream registry_1.7.2_checksums.txt — bump
+          # alongside the `version` above when upgrading the publisher.
+          expected_sha="9a324bab0bc69bf957599d7975b663d7c4169eba2cdc00baf0f589b847e03898"
+          url="https://github.com/modelcontextprotocol/registry/releases/download/${version}/${tarball}"
           curl -fsSL "$url" -o /tmp/mcp-publisher.tar.gz
+          echo "${expected_sha}  /tmp/mcp-publisher.tar.gz" | sha256sum -c -
           mkdir -p /tmp/mcp-publisher
           tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp/mcp-publisher
           echo "/tmp/mcp-publisher" >> "$GITHUB_PATH"
+
+      - name: Sanity-check publisher binary
+        run: mcp-publisher --help | head -1
 
       - name: Validate server.json
         run: mcp-publisher validate

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "qurl-mcp-v*"
+  # workflow_dispatch checks out the workflow file's branch (main) by default,
+  # not the most recent tag — fine for re-publishing the current main's
+  # server.json, but if you need to publish an older release, add
+  # `inputs.ref` and pass it to actions/checkout.
   workflow_dispatch:
 
 permissions:
@@ -27,14 +31,14 @@ jobs:
           # alongside the `version` above when upgrading the publisher.
           expected_sha="9a324bab0bc69bf957599d7975b663d7c4169eba2cdc00baf0f589b847e03898"
           url="https://github.com/modelcontextprotocol/registry/releases/download/${version}/${tarball}"
-          curl -fsSL "$url" -o /tmp/mcp-publisher.tar.gz
+          curl -fsSL --retry 3 --retry-delay 5 "$url" -o /tmp/mcp-publisher.tar.gz
           echo "${expected_sha}  /tmp/mcp-publisher.tar.gz" | sha256sum -c -
           mkdir -p /tmp/mcp-publisher
           tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp/mcp-publisher
           echo "/tmp/mcp-publisher" >> "$GITHUB_PATH"
 
       - name: Sanity-check publisher binary
-        run: mcp-publisher --help | head -1
+        run: mcp-publisher --help > /dev/null
 
       - name: Validate server.json
         run: mcp-publisher validate

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,39 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags:
+      - "qurl-mcp-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # Required for github-oidc auth
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install mcp-publisher
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="v1.7.2"
+          url="https://github.com/modelcontextprotocol/registry/releases/download/${version}/mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL "$url" -o /tmp/mcp-publisher.tar.gz
+          mkdir -p /tmp/mcp-publisher
+          tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp/mcp-publisher
+          echo "/tmp/mcp-publisher" >> "$GITHUB_PATH"
+
+      - name: Validate server.json
+        run: mcp-publisher validate
+
+      - name: Authenticate with GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: mcp-publisher publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,13 @@ The repository includes an API spec drift detection system:
 - **Action:** When an issue is opened, review the diff, update `api-spec/qurls.yaml`, update client types/tools as needed, and verify with `npm run build && npm run lint && npm test`.
 - **Spec URL:** Configurable via the `QURL_API_SPEC_URL` repository variable. Defaults to `https://api.layerv.ai/v1/openapi.yaml`.
 
+## MCP Registry
+
+- **Manifest:** `server.json` (validated against the registry's JSON Schema). Both `$.version` and `$.packages[0].version` are kept in sync with `package.json` automatically by release-please's `extra-files` config.
+- **Publishing:** `.github/workflows/publish-mcp-registry.yml` runs on every `qurl-mcp-v*` tag and uses GitHub OIDC for keyless auth (no PATs).
+- **Description divergence:** `server.json.description` is intentionally shorter than `package.json.description` because the registry hard-caps descriptions at 100 characters. Don't "fix" by aligning them — keep the npm/site copy long-form, and the registry copy concise.
+- **Pinning:** the workflow pins both `actions/checkout` and the `mcp-publisher` tarball SHA. Bump them in lockstep when upgrading the publisher.
+
 ## Security Notes
 
 - Never commit API keys or secrets

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,19 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
+        }
+      ]
     }
   }
 }

--- a/server.json
+++ b/server.json
@@ -2,18 +2,18 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.layervai/qurl-mcp",
   "title": "qURL",
-  "description": "Mint, resolve, audit, and rotate expiring, scope-limited access links (qURLs) for AI agents — secure URL gateway for the qURL API. Lets agents act through scoped, expiring URLs instead of receiving raw credentials.",
+  "description": "Mint, resolve, audit, and rotate scope-limited expiring access links (qURLs) for AI agents.",
   "websiteUrl": "https://layerv.ai",
   "repository": {
     "url": "https://github.com/layervai/qurl-mcp",
     "source": "github"
   },
-  "version": "0.2.1",
+  "version": "0.3.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@layerv/qurl-mcp",
-      "version": "0.2.1",
+      "version": "0.3.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

The MCP Registry currently has no listing for this server (\`registry.modelcontextprotocol.io/v0/servers?search=qurl\` returns empty). \`server.json\` was added in PR #70 at version 0.2.1 and never bumped — meanwhile we shipped v0.2.0 → v0.3.4 to npm. This PR closes the gap on three axes at once.

## Changes

### 1. \`server.json\` — bring it current
- \`version\`: \`0.2.1\` → \`0.3.4\` (matches npm latest)
- \`packages[0].version\`: same bump
- \`description\` trimmed to ≤100 chars (registry validator hard-rejected the previous 250-char text)

Validated locally: \`mcp-publisher validate\` returns ✅.

### 2. \`release-please-config.json\` — kill the drift
\`extra-files\` entry teaches release-please to bump both \`\$.version\` and \`\$.packages[0].version\` in \`server.json\` on every release. Without this, every future release would re-open the same gap PR #70 left.

### 3. \`.github/workflows/publish-mcp-registry.yml\` — automate the publish
Triggers on the \`qurl-mcp-v*\` tags release-please pushes. Installs \`mcp-publisher\` (v1.7.2 from upstream releases), validates \`server.json\`, authenticates via **GitHub OIDC** (\`id-token: write\`, no PATs needed), and publishes.

After this PR merges + the next release-please cut runs:
- Every \`feat:\` / \`fix:\` to main → release-please opens a release PR
- Merging the release PR → tag pushed → npm + GitHub release + MCP Registry update, all in one swoop.

## Verified

- \`npm run build && npm run lint && npm test\` — 373/373 pass
- \`mcp-publisher validate\` against \`https://registry.modelcontextprotocol.io\` — ✅

## Test plan

- [x] Server.json valid against the registry's schema
- [ ] CI green
- [ ] After merge, the publish workflow can be manually dispatched (\`workflow_dispatch:\`) to seed the registry without waiting for the next release tag
- [ ] First automatic run on the next release confirms end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)