### PR TITLE
chore(ci): add smithery.yaml for Smithery MCP listing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,12 @@ The repository includes an API spec drift detection system:
 - **Description divergence:** `server.json.description` is intentionally shorter than `package.json.description` because the registry hard-caps descriptions at 100 characters. Don't "fix" by aligning them — keep the npm/site copy long-form, and the registry copy concise.
 - **Pinning:** the workflow pins both `actions/checkout` and the `mcp-publisher` tarball SHA. Bump them in lockstep when upgrading the publisher.
 
+## Smithery
+
+- **Manifest:** `smithery.yaml`. Powers smithery.ai's auto-detect import flow.
+- **Hand-synced:** `configSchema` is kept in sync with `server.json.environmentVariables` by hand. Adding or renaming an env var means updating both manifests; there's no automated sync.
+- **Default URLs duplicated:** `https://api.layerv.ai` appears in three places — `smithery.yaml`'s schema default, the `commandFunction` fallback, and `src/index.ts` runtime default. If the production URL ever moves, all three move in lockstep. The duplication is deliberate (defense-in-depth against consumers that don't apply JSON Schema defaults).
+
 ## Security Notes
 
 - Never commit API keys or secrets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ The repository includes an API spec drift detection system:
 
 - **Manifest:** `smithery.yaml`. Powers smithery.ai's auto-detect import flow.
 - **Hand-synced:** `configSchema` is kept in sync with `server.json.environmentVariables` by hand. Adding or renaming an env var means updating both manifests; there's no automated sync.
-- **Default URLs duplicated:** `https://api.layerv.ai` appears in three places — `smithery.yaml`'s schema default, the `commandFunction` fallback, and `src/index.ts` runtime default. If the production URL ever moves, all three move in lockstep. The duplication is deliberate (defense-in-depth against consumers that don't apply JSON Schema defaults).
+- **Default URLs duplicated:** `https://api.layerv.ai` appears in four places — `smithery.yaml`'s schema default, the `commandFunction` fallback, `server.json`'s `environmentVariables[].default`, and `src/index.ts` runtime default. If the production URL ever moves, all four move in lockstep. The duplication is deliberate (defense-in-depth against consumers that don't apply JSON Schema defaults).
 
 ## Security Notes
 

--- a/server.json
+++ b/server.json
@@ -27,7 +27,7 @@
         },
         {
           "name": "QURL_API_URL",
-          "description": "qURL API base URL. Defaults to https://api.layerv.ai.",
+          "description": "qURL API base URL. Defaults to https://api.layerv.ai. Override only for testing against a non-production qURL backend.",
           "isRequired": false,
           "format": "string",
           "default": "https://api.layerv.ai"

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -7,6 +7,11 @@ startCommand:
     properties:
       qurlApiKey:
         type: string
+        # JSON Schema's `format: password` is the standard convention for
+        # input-masking. Smithery's UI rendering of this hint isn't formally
+        # documented; mirroring server.json's `isSecret: true` here in the
+        # form Smithery is most likely to honor.
+        format: password
         description: |
           API key for the qURL API with qurl:read, qurl:write, and/or qurl:resolve scopes.
           Obtain from https://layerv.ai.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,27 @@
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - qurlApiKey
+    properties:
+      qurlApiKey:
+        type: string
+        description: |
+          API key for the qURL API with qurl:read, qurl:write, and/or qurl:resolve scopes.
+          Obtain from https://layerv.ai.
+      qurlApiUrl:
+        type: string
+        description: |
+          qURL API base URL. Defaults to https://api.layerv.ai. Override only for testing
+          against a non-production qURL backend.
+        default: https://api.layerv.ai
+  commandFunction: |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', '@layerv/qurl-mcp'],
+      env: {
+        QURL_API_KEY: config.qurlApiKey,
+        QURL_API_URL: config.qurlApiUrl || 'https://api.layerv.ai',
+      },
+    })


### PR DESCRIPTION
## Summary

Adds \`smithery.yaml\` so [smithery.ai](https://smithery.ai) can auto-detect this server's start spec when the repo is connected to a Smithery listing. Without this file, Smithery's import falls back to repo-only inspection and the host-side install block can't be generated.

## Schema

Mirrors \`server.json.environmentVariables\` so the two manifests don't drift in user-visible ways:

- \`qurlApiKey\` (required, secret) — maps to \`QURL_API_KEY\`
- \`qurlApiUrl\` (optional, default \`https://api.layerv.ai\`) — maps to \`QURL_API_URL\`

\`commandFunction\` shells out to \`npx -y @layerv/qurl-mcp\` so the published npm package remains the source of truth (no Dockerfile path needed for stdio transport).

## Next step (manual, can't be done from a PR)

Connect the repo to Smithery via their dashboard's GitHub OAuth flow. With this file present, the connect step picks up the schema automatically rather than asking the maintainer to fill it in by hand.

## Verified

- \`npm run build && npm run lint && npm test\` — 373/373 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)