### PR TITLE
feat!: rename npm package to @layervai/qurl-mcp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,8 +76,8 @@ body:
     id: version
     attributes:
       label: Package version
-      description: Run `npm list @layerv/qurl-mcp` or check the installed version in your MCP client config.
-      placeholder: e.g. 0.3.x
+      description: Run `npm list @layervai/qurl-mcp` (or `@layerv/qurl-mcp` for ≤ 0.3.x — that scope is deprecated as of 0.4.0) or check the installed version in your MCP client config.
+      placeholder: e.g. 0.4.x
     validations:
       required: true
   - type: input

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ npm run format
   "mcpServers": {
     "qurl": {
       "command": "npx",
-      "args": ["@layerv/qurl-mcp"],
+      "args": ["@layervai/qurl-mcp"],
       "env": { "QURL_API_KEY": "lv_live_xxx" }
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# @layerv/qurl-mcp
+# @layervai/qurl-mcp
 
-[![npm version](https://img.shields.io/npm/v/@layerv/qurl-mcp.svg)](https://www.npmjs.com/package/@layerv/qurl-mcp)
+[![npm version](https://img.shields.io/npm/v/@layervai/qurl-mcp.svg)](https://www.npmjs.com/package/@layervai/qurl-mcp)
+
+> **⚠️ Renamed from `@layerv/qurl-mcp` in v0.4.0.** The old package is deprecated and will not receive further updates. If you're using `@layerv/qurl-mcp@0.3.x`, swap the scope in your MCP client config — same binary, same API key, no other changes.
 
 MCP server for qURL™ secure link management.
 
@@ -19,7 +21,7 @@ Add the server to your MCP client configuration (Claude Desktop, Claude Code, et
   "mcpServers": {
     "qurl": {
       "command": "npx",
-      "args": ["@layerv/qurl-mcp"],
+      "args": ["@layervai/qurl-mcp"],
       "env": { "QURL_API_KEY": "lv_live_xxx" }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@layerv/qurl-mcp",
+  "name": "@layervai/qurl-mcp",
   "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@layerv/qurl-mcp",
+      "name": "@layervai/qurl-mcp",
       "version": "0.3.4",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@layerv/qurl-mcp",
+  "name": "@layervai/qurl-mcp",
   "version": "0.3.4",
   "description": "MCP server for qURL™ — secure link management for AI agents. Quantum URL is how you enter the hidden layer of the internet.",
   "mcpName": "io.github.layervai/qurl-mcp",

--- a/server.json
+++ b/server.json
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "npm",
-      "identifier": "@layerv/qurl-mcp",
+      "identifier": "@layervai/qurl-mcp",
       "version": "0.3.4",
       "transport": {
         "type": "stdio"

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -24,7 +24,7 @@ startCommand:
   commandFunction: |-
     (config) => ({
       command: 'npx',
-      args: ['-y', '@layerv/qurl-mcp'],
+      args: ['-y', '@layervai/qurl-mcp'],
       env: {
         QURL_API_KEY: config.qurlApiKey,
         QURL_API_URL: config.qurlApiUrl || 'https://api.layerv.ai',


### PR DESCRIPTION
## Summary

Aligns the npm scope with everywhere else (GitHub org \`layervai\`, MCP Registry \`io.github.layervai/qurl-mcp\`, Glama, mcpservers.org, Smithery namespace). The \`@layerv\` scope was a leftover from initial publish that diverged from the rest of the surface area.

> **Breaking change.** Existing users on \`@layerv/qurl-mcp@0.3.x\` need to update their MCP client config to use \`@layervai/qurl-mcp\`. **No code, env vars, API keys, or tool surface changed** — pure rename. We'll \`npm deprecate\` the old scope post-release so existing installs surface a migration warning.

## Why now

This is the cheapest moment to do it. The package shipped publicly only days ago; existing users are very few. Each week we delay makes the migration cost worse.

## Changes

- \`package.json\` — \`name\`: \`@layerv/qurl-mcp\` → \`@layervai/qurl-mcp\`
- \`package-lock.json\` — regenerated
- \`README.md\` — migration banner at the top + all install snippets
- \`server.json\` — \`packages[0].identifier\` (revalidated against registry; ✅)
- \`smithery.yaml\` — \`commandFunction\` args
- \`CLAUDE.md\` — example configs
- \`.github/ISSUE_TEMPLATE/bug_report.yml\` — carries both names so 0.3.x reporters can still find the right \`npm list\` invocation

## Why \`feat!:\` and not \`fix!:\`

This is a deliberate, planned breaking change at the install surface, not a bug. The conventional \`!\` marker plus the \`BREAKING CHANGE:\` footer in the commit message lets release-please cut the right release notes.

## Verified

- \`npm install\` succeeds, \`npm run build && npm run lint && npm test\` — 373/373 pass
- \`mcp-publisher validate\` against \`https://registry.modelcontextprotocol.io\` — ✅

## Post-merge release path

1. Release Please cuts a 0.4.0 release PR (\`feat!:\` triggers minor pre-major bump per our config). **0.4.0 is what users will install going forward.**
2. Merging the release PR pushes the \`qurl-mcp-v0.4.0\` tag.
3. Existing publish workflows fire:
   - \`release-please.yml\` → publishes \`@layervai/qurl-mcp@0.4.0\` to npm with provenance.
   - \`publish-mcp-registry.yml\` → publishes \`io.github.layervai/qurl-mcp@0.4.0\` to the MCP Registry.
4. **Manual step** (requires npm 2FA, can't be done from CI): run \`npm deprecate \"@layerv/qurl-mcp@*\" \"moved to @layervai/qurl-mcp — see https://github.com/layervai/qurl-mcp\"\` so old-scope installs surface a clear deprecation warning.
5. Update \`mcpservers.org\` listing's install command if it embedded the old scope (the listing page renders install instructions from somewhere — worth a glance).
6. The Smithery listing (when set up) and Glama listing should pick up the new scope on their next scan.

## Backward compatibility

There isn't any — npm scopes are not aliasable. \`@layerv/qurl-mcp\` will continue to install \`0.3.x\` indefinitely (npm doesn't unpublish), but won't get patches. The \`npm deprecate\` warning is the migration nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)