### PR TITLE
ci: emit aggregate commit status on main for legacy status API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,36 @@ jobs:
           echo "$out" | grep -q "QURL_API_KEY is not set" || { echo "tools/call response missing the actionable error message"; echo "$out"; exit 1; }
           echo "MCP introspection OK; all 9 tools exposed; warning printed; tools/call surfaces missing_api_key as expected"
 
+  ci-status:
+    name: ci-status
+    needs: [lint, test, docker]
+    # GitHub Actions only writes check-runs, but the legacy combined-status
+    # API (read by external probes like Glama's MCP catalog) only sees commit
+    # statuses. This job mirrors the aggregate result onto the legacy API so
+    # `GET /commits/main/status` flips from `pending` to `success`.
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Set commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          DOCKER_RESULT: ${{ needs.docker.result }}
+        run: |
+          if [[ "$LINT_RESULT" == "success" && "$TEST_RESULT" == "success" && "$DOCKER_RESULT" == "success" ]]; then
+            STATE="success"
+          else
+            STATE="failure"
+          fi
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -f state="$STATE" \
+            -f context="ci/aggregate" \
+            -f description="lint=$LINT_RESULT test=$TEST_RESULT docker=$DOCKER_RESULT" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   notify:
     name: Notify
     needs: [lint, test, docker]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
     # `GET /commits/main/status` flips from `pending` to `success`.
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Best-effort mirror: the upstream check-runs are authoritative. A
+    # transient GitHub API blip leaves the legacy status unset for that SHA;
+    # the next push to main overwrites it. Don't fail the workflow over it.
+    continue-on-error: true
     permissions:
       statuses: write
     steps:
@@ -114,17 +118,24 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           TEST_RESULT: ${{ needs.test.result }}
           DOCKER_RESULT: ${{ needs.docker.result }}
+          GH_REPO: ${{ github.repository }}
+          GH_SHA: ${{ github.sha }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SERVER_URL: ${{ github.server_url }}
         run: |
+          # All three jobs always run on push to main today; if any gain a
+          # `paths:` filter later, a `skipped` result would falsely report
+          # `failure` here. Revisit the skipped→failure mapping at that point.
           if [[ "$LINT_RESULT" == "success" && "$TEST_RESULT" == "success" && "$DOCKER_RESULT" == "success" ]]; then
             STATE="success"
           else
             STATE="failure"
           fi
-          gh api -X POST "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+          gh api -X POST "repos/$GH_REPO/statuses/$GH_SHA" \
             -f state="$STATE" \
             -f context="ci/aggregate" \
             -f description="lint=$LINT_RESULT test=$TEST_RESULT docker=$DOCKER_RESULT" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="$GH_SERVER_URL/$GH_REPO/actions/runs/$GH_RUN_ID"
 
   notify:
     name: Notify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
     # `GET /commits/main/status` flips from `pending` to `success`.
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Best-effort mirror: the upstream check-runs are authoritative. A
     # transient GitHub API blip leaves the legacy status unset for that SHA;
     # the next push to main overwrites it. Don't fail the workflow over it.
@@ -126,8 +127,13 @@ jobs:
           # All three jobs always run on push to main today; if any gain a
           # `paths:` filter later, a `skipped` result would falsely report
           # `failure` here. Revisit the skipped→failure mapping at that point.
+          # Map cancellations to `error` (the legacy status enum's
+          # conventional slot for "didn't run to completion") rather than
+          # collapsing them into `failure`.
           if [[ "$LINT_RESULT" == "success" && "$TEST_RESULT" == "success" && "$DOCKER_RESULT" == "success" ]]; then
             STATE="success"
+          elif [[ "$LINT_RESULT" == "cancelled" || "$TEST_RESULT" == "cancelled" || "$DOCKER_RESULT" == "cancelled" ]]; then
+            STATE="error"
           else
             STATE="failure"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,14 +103,24 @@ jobs:
     # API (read by external probes like Glama's MCP catalog) only sees commit
     # statuses. This job mirrors the aggregate result onto the legacy API so
     # `GET /commits/main/status` flips from `pending` to `success`.
+    #
+    # DO NOT add `ci/aggregate` to branch protection required checks: this
+    # job only fires on `push` to `main`, so configuring it as a required PR
+    # check would block all PRs from merging (the check would never report).
+    # The legacy status exists for external probes (Glama), not for gating.
+    #
+    # `if: always()` is intentional: even when lint/test/docker fail, we want
+    # to mirror `failure`/`error` to the legacy API instead of leaving it
+    # stuck at `pending`. `continue-on-error: true` is the complementary
+    # safety: a transient gh-api blip on the mirror itself shouldn't redden
+    # the workflow when the upstream check-runs (the source of truth) are
+    # already authoritative.
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Best-effort mirror: the upstream check-runs are authoritative. A
-    # transient GitHub API blip leaves the legacy status unset for that SHA;
-    # the next push to main overwrites it. Don't fail the workflow over it.
     continue-on-error: true
     permissions:
+      actions: read
       statuses: write
     steps:
       - name: Set commit status
@@ -122,6 +132,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_SHA: ${{ github.sha }}
           GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
           GH_SERVER_URL: ${{ github.server_url }}
         run: |
           # All three jobs always run on push to main today; if any gain a
@@ -137,11 +148,23 @@ jobs:
           else
             STATE="failure"
           fi
+          # Resolve this job's numeric runner-job id so the legacy status
+          # deep-links to the mirror step, not the run summary. `github.job`
+          # gives the YAML key; the URL needs the numeric id from the API.
+          # On any lookup failure, fall back to the run-level URL.
+          TARGET_URL="$GH_SERVER_URL/$GH_REPO/actions/runs/$GH_RUN_ID"
+          JOB_ID=$(gh api \
+            "repos/$GH_REPO/actions/runs/$GH_RUN_ID/attempts/$GH_RUN_ATTEMPT/jobs" \
+            --jq '.jobs[] | select(.name == "ci-status") | .id' 2>/dev/null \
+            | head -n1) || JOB_ID=""
+          if [[ -n "$JOB_ID" ]]; then
+            TARGET_URL="$GH_SERVER_URL/$GH_REPO/actions/runs/$GH_RUN_ID/job/$JOB_ID"
+          fi
           gh api -X POST "repos/$GH_REPO/statuses/$GH_SHA" \
             -f state="$STATE" \
             -f context="ci/aggregate" \
             -f description="lint=$LINT_RESULT test=$TEST_RESULT docker=$DOCKER_RESULT" \
-            -f target_url="$GH_SERVER_URL/$GH_REPO/actions/runs/$GH_RUN_ID"
+            -f target_url="$TARGET_URL"
 
   notify:
     name: Notify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,10 @@ jobs:
           echo "MCP introspection OK; all 9 tools exposed; warning printed; tools/call surfaces missing_api_key as expected"
 
   ci-status:
-    name: ci-status
+    # `name:` is intentionally omitted: the runner-job lookup below filters
+    # by `${{ github.job }}` (the YAML key), and the API's `.name` defaults
+    # to the key when `name:` is unset. Keeping them auto-aligned avoids a
+    # silent deep-link miss if someone renames one but forgets the other.
     needs: [lint, test, docker]
     # GitHub Actions only writes check-runs, but the legacy combined-status
     # API (read by external probes like Glama's MCP catalog) only sees commit
@@ -149,14 +152,17 @@ jobs:
             STATE="failure"
           fi
           # Resolve this job's numeric runner-job id so the legacy status
-          # deep-links to the mirror step, not the run summary. `github.job`
-          # gives the YAML key; the URL needs the numeric id from the API.
-          # On any lookup failure, fall back to the run-level URL.
+          # deep-links to the mirror step, not the run summary. The URL
+          # needs the numeric id from the API. Self-heal on rename by
+          # matching on `${{ github.job }}` (the YAML key) — the job's
+          # `name:` is omitted, so the API's `.name` defaults to the key
+          # and the two stay aligned automatically.
+          # On any lookup miss, fall back to the run-level URL.
           TARGET_URL="$GH_SERVER_URL/$GH_REPO/actions/runs/$GH_RUN_ID"
           JOB_ID=$(gh api \
             "repos/$GH_REPO/actions/runs/$GH_RUN_ID/attempts/$GH_RUN_ATTEMPT/jobs" \
-            --jq '.jobs[] | select(.name == "ci-status") | .id' 2>/dev/null \
-            | head -n1) || JOB_ID=""
+            --jq ".jobs[] | select(.name == \"${{ github.job }}\") | .id" 2>/dev/null \
+            | head -n1)
           if [[ -n "$JOB_ID" ]]; then
             TARGET_URL="$GH_SERVER_URL/$GH_REPO/actions/runs/$GH_RUN_ID/job/$JOB_ID"
           fi


### PR DESCRIPTION
## Summary
- Adds a `ci-status` job that mirrors the lint/test/docker aggregate onto the legacy commit-status API on every push to `main`.
- Glama's MCP catalog (and other tools that read `GET /commits/{sha}/status`) currently see `state: pending` with empty statuses because GitHub Actions only writes check-runs. This flips them to `success` and clears Glama's "CI status not available" finding.
- No PR-time behavior change — the new job only runs on `push` to `main`.

## Note for future maintainers
**Do not add `ci/aggregate` to branch protection required checks.** This context only fires on `push` to `main`; configuring it as a required PR check would block all PRs from merging (the check would never report). It exists for external probes like Glama, not for gating.

## Test plan
- [ ] After merge, `gh api repos/layervai/qurl-mcp/commits/main/status --jq .state` returns `success` instead of `pending`.
- [ ] Glama maintenance score panel shows the CI status check ✓ on next rescore.
- [ ] Branch protection / PR-required checks unchanged (job is gated on `push` + `refs/heads/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)