### PR TITLE
docs(tools): pilot TDQS rewrite for list_qurls and create_qurl

### DIFF
--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, vi } from "vitest";
 import type { IQURLClient } from "../client.js";
 import { toolFactories } from "../server.js";
@@ -94,6 +96,19 @@ describe("TDQS tool metadata coverage", () => {
     // structural check — drift inside a nested object surfaces via the
     // round-trip test below.
     //
+    // **One-directional by design.** This enforces description ⊆ schema:
+    // a key claimed in the description must exist in the schema. It does
+    // *not* enforce the inverse (every schema key must be documented).
+    // Adding a schema field without updating the description will pass
+    // this test silently — that's intentional, since not every field is
+    // worth surfacing in the description, but flagging so a future
+    // reader doesn't assume bidirectional coverage.
+    //
+    // **Bare keys only.** The walker matches identifier-followed-by-colon
+    // at depth 0. A future Returns block that wraps keys in backticks or
+    // quotes (e.g. `` `success`: literal `true` ``) will skip them
+    // silently — adapt the walker if/when that pattern shows up.
+    //
     // Tools without a Returns block (or whose block describes a
     // discriminated/wrapped shape) are skipped here.
     const topLevelKeys = (body: string): string[] => {
@@ -140,6 +155,33 @@ describe("TDQS tool metadata coverage", () => {
         }
       });
     }
+  });
+
+  describe("description claims pinned against api-spec defaults", () => {
+    // Strong factual claims about API defaults (e.g. "expires_in defaults
+    // to 24h") become silent lies if the server-side default moves. Read
+    // the snapshot at api-spec/qurls.yaml — the same file the spec-drift
+    // workflow already monitors — and assert the description quotes the
+    // value verbatim. If the spec changes, the drift workflow updates the
+    // file and this test forces a description update at the same time.
+    const specPath = fileURLToPath(new URL("../../api-spec/qurls.yaml", import.meta.url));
+    const spec = readFileSync(specPath, "utf8");
+
+    it("create_qurl description matches the spec's expires_in default", () => {
+      // Anchor on the schema block (`expires_in:` followed by `type:`),
+      // not on the first `expires_in:` token in the file — earlier
+      // occurrences are example values inside response samples and
+      // would let an unrelated `Default:` field between here and the
+      // real schema slip into the capture group.
+      const match = spec.match(/expires_in:\s*\n\s*type:[\s\S]*?Default:\s*(\d+\s*[a-z]+)/);
+      expect(match, "expected to find an `expires_in: type: … Default: …` block in api-spec/qurls.yaml").not.toBeNull();
+      const specDefault = match![1].trim();
+      const description = tools.find((t) => t.name === "create_qurl")!.description;
+      expect(
+        description,
+        `create_qurl description must mention the spec's expires_in default '${specDefault}'`,
+      ).toContain(specDefault);
+    });
   });
 
   describe("safety hints match tool semantics", () => {

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -171,11 +171,13 @@ describe("TDQS tool metadata coverage", () => {
     const spec = readFileSync(specPath, "utf8");
 
     it("create_qurl description matches the spec's expires_in default", () => {
-      // The spec has two `expires_in:` properties (one each on the
-      // CreateQurl and UpdateQurl request schemas) — only the create-side
-      // declares a `Default:`. Iterate every match and pick the block
-      // that carries the default; relying on source order would silently
-      // pick the wrong block if the schemas ever swap positions.
+      // The spec has two `expires_in: type: string` blocks (CreateQurlRequest
+      // and MintLinkRequest) — only the create-side declares a `Default:`
+      // inside its own description (MintLink puts the 24h default in the
+      // parent schema description, not the property's). Iterate every match
+      // and pick the block that carries `Default:`; relying on source
+      // order would silently pick the wrong block if the schemas ever
+      // swap positions.
       //
       // Indent matcher is `[ ]{12,}` (description-body depth) rather than
       // `\s+` so the captured block stops at the next outdented line —

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -168,26 +168,31 @@ describe("TDQS tool metadata coverage", () => {
     const spec = readFileSync(specPath, "utf8");
 
     it("create_qurl description matches the spec's expires_in default", () => {
-      // Two-step extraction to avoid the non-greedy `[\s\S]*?Default:` walking
-      // past expires_in into a sibling property's description block:
-      //   1. Capture the multi-line `description: |` block under `expires_in:`
-      //      (consecutive indented continuation lines).
-      //   2. Search for `Default:` only inside that captured block.
-      // If Default isn't in expires_in's own block, the second match is null
-      // and the assertion fires — regardless of what later properties carry.
-      const blockMatch = spec.match(
-        /expires_in:\s*\n\s*type:\s*string\s*\n\s*description:\s*\|\s*\n((?:\s+[^\n]+\n)+)/,
-      );
+      // The spec has two `expires_in:` properties (one each on the
+      // CreateQurl and UpdateQurl request schemas) — only the create-side
+      // declares a `Default:`. Iterate every match and pick the block
+      // that carries the default; relying on source order would silently
+      // pick the wrong block if the schemas ever swap positions.
+      //
+      // Indent matcher is `[ ]{12,}` (description-body depth) rather than
+      // `\s+` so the captured block stops at the next outdented line —
+      // sibling property values (`example:`) sit at 10 spaces, sibling
+      // properties (`one_time_use:`) at 8 — both correctly excluded.
+      const blocks = [
+        ...spec.matchAll(
+          /expires_in:\s*\n\s*type:\s*string\s*\n\s*description:\s*\|\s*\n((?:[ ]{12,}[^\n]+\n)+)/g,
+        ),
+      ];
       expect(
-        blockMatch,
-        "expected an `expires_in: type: string, description: |` block in api-spec/qurls.yaml",
-      ).not.toBeNull();
-      const defaultMatch = blockMatch![1].match(/Default:\s*(\d+\s*[a-z]+)/);
+        blocks.length,
+        "expected at least one `expires_in: type: string, description: |` block in api-spec/qurls.yaml",
+      ).toBeGreaterThan(0);
+      const blockWithDefault = blocks.find((m) => /Default:\s*\d+\s*[a-z]+/.test(m[1]));
       expect(
-        defaultMatch,
-        "expected a `Default: …` line inside expires_in's description block",
-      ).not.toBeNull();
-      const specDefault = defaultMatch![1].trim();
+        blockWithDefault,
+        "no expires_in description block in api-spec/qurls.yaml carries a `Default: …` line",
+      ).toBeDefined();
+      const specDefault = blockWithDefault![1].match(/Default:\s*(\d+\s*[a-z]+)/)![1].trim();
       const description = tools.find((t) => t.name === "create_qurl")!.description;
       expect(
         description,

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -146,11 +146,30 @@ describe("TDQS tool metadata coverage", () => {
       }
       return keys;
     };
+    // Find `**Returns:** \`{ ... }\`` and return the body between the
+    // outermost balanced braces. A non-greedy regex would truncate at
+    // the first `}` (e.g. inside `meta: { … }`) and silently miss any
+    // top-level keys that follow the nested object — this walker
+    // returns the full balanced body so topLevelKeys sees them all.
+    const extractReturnsBody = (description: string): string | null => {
+      const marker = description.match(/\*\*Returns:\*\*\s*`\{/);
+      if (!marker || marker.index === undefined) return null;
+      const open = marker.index + marker[0].length - 1;
+      let depth = 0;
+      for (let i = open; i < description.length; i++) {
+        if (description[i] === "{") depth++;
+        else if (description[i] === "}") {
+          depth--;
+          if (depth === 0) return description.slice(open + 1, i);
+        }
+      }
+      return null;
+    };
     for (const tool of tools) {
-      const match = tool.description.match(/\*\*Returns:\*\*\s*`\{([\s\S]+?)\}`/);
-      if (!match) continue;
+      const body = extractReturnsBody(tool.description);
+      if (body === null) continue;
       it(`${tool.name} Returns block lists only schema keys`, () => {
-        const claimed = topLevelKeys(match[1]);
+        const claimed = topLevelKeys(body);
         expect(claimed.length, `${tool.name} Returns block parsed zero keys`).toBeGreaterThan(0);
         const schemaKeys = new Set(Object.keys(tool.outputSchema.shape));
         for (const key of claimed) {

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -168,14 +168,26 @@ describe("TDQS tool metadata coverage", () => {
     const spec = readFileSync(specPath, "utf8");
 
     it("create_qurl description matches the spec's expires_in default", () => {
-      // Anchor on the schema block (`expires_in:` followed by `type:`),
-      // not on the first `expires_in:` token in the file — earlier
-      // occurrences are example values inside response samples and
-      // would let an unrelated `Default:` field between here and the
-      // real schema slip into the capture group.
-      const match = spec.match(/expires_in:\s*\n\s*type:[\s\S]*?Default:\s*(\d+\s*[a-z]+)/);
-      expect(match, "expected to find an `expires_in: type: … Default: …` block in api-spec/qurls.yaml").not.toBeNull();
-      const specDefault = match![1].trim();
+      // Two-step extraction to avoid the non-greedy `[\s\S]*?Default:` walking
+      // past expires_in into a sibling property's description block:
+      //   1. Capture the multi-line `description: |` block under `expires_in:`
+      //      (consecutive indented continuation lines).
+      //   2. Search for `Default:` only inside that captured block.
+      // If Default isn't in expires_in's own block, the second match is null
+      // and the assertion fires — regardless of what later properties carry.
+      const blockMatch = spec.match(
+        /expires_in:\s*\n\s*type:\s*string\s*\n\s*description:\s*\|\s*\n((?:\s+[^\n]+\n)+)/,
+      );
+      expect(
+        blockMatch,
+        "expected an `expires_in: type: string, description: |` block in api-spec/qurls.yaml",
+      ).not.toBeNull();
+      const defaultMatch = blockMatch![1].match(/Default:\s*(\d+\s*[a-z]+)/);
+      expect(
+        defaultMatch,
+        "expected a `Default: …` line inside expires_in's description block",
+      ).not.toBeNull();
+      const specDefault = defaultMatch![1].trim();
       const description = tools.find((t) => t.name === "create_qurl")!.description;
       expect(
         description,

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -218,11 +218,19 @@ describe("TDQS tool metadata coverage", () => {
       const { listQurlsSchema } = await import("../tools/list-qurls.js");
       const description = tools.find((t) => t.name === "list_qurls")!.description;
       const statusFieldDescription = listQurlsSchema.shape.status.description ?? "";
-      const sentinel = "active";
-      expect(statusFieldDescription, "list_qurls.status .describe() must mention the active default").toContain(
-        sentinel,
-      );
-      expect(description, "list_qurls description must mention the active default").toContain(sentinel);
+      // Sentinels must uniquely encode the *default-active claim*, not just
+      // mention the word `active` (which appears in unrelated contexts: the
+      // example block, the "everything still active" prose, the comma-
+      // separated enum). Without a claim-specific phrase, the test would
+      // silently pass if both sides dropped the default claim entirely.
+      expect(
+        statusFieldDescription,
+        "list_qurls.status .describe() must assert the active default with the phrase \"Defaults to 'active'\"",
+      ).toContain("Defaults to 'active'");
+      expect(
+        description,
+        "list_qurls description must assert the active default with the phrase \"By default only `active`\"",
+      ).toContain("By default only `active`");
     });
   });
 

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -117,9 +117,29 @@ describe("TDQS tool metadata coverage", () => {
       // re-slicing on every iteration.
       const keyRe = /([a-zA-Z_]\w*)\??\s*:/y;
       let depth = 0;
+      // Skip everything inside a quoted/backticked literal so a prose
+      // colon (e.g. `string ("RFC 3339: timestamps")`) doesn't capture
+      // the preceding word as a fake key. Tracks the active opener; null
+      // means we're not in a string.
+      let inString: '"' | "'" | "`" | null = null;
       let i = 0;
       while (i < body.length) {
         const ch = body[i];
+        if (inString !== null) {
+          if (ch === "\\") {
+            // Skip the escaped char so an escaped quote doesn't end the literal.
+            i += 2;
+            continue;
+          }
+          if (ch === inString) inString = null;
+          i++;
+          continue;
+        }
+        if (ch === '"' || ch === "'" || ch === "`") {
+          inString = ch;
+          i++;
+          continue;
+        }
         if (ch === "{") {
           depth++;
           i++;

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -69,6 +69,8 @@ describe("TDQS tool metadata coverage", () => {
       extend_qurl: ["update_qurl"],
       mint_link: ["create_qurl", "update_qurl"],
       batch_create_qurls: ["create_qurl"],
+      list_qurls: ["get_qurl", "resolve_qurl"],
+      create_qurl: ["mint_link", "batch_create_qurls", "update_qurl"],
     };
     const byName = new Map(tools.map((t) => [t.name, t]));
     for (const [name, siblings] of Object.entries(expected)) {
@@ -76,6 +78,65 @@ describe("TDQS tool metadata coverage", () => {
         const description = byName.get(name)?.description ?? "";
         for (const sibling of siblings) {
           expect(description).toContain(sibling);
+        }
+      });
+    }
+  });
+
+  describe("Returns block keys exist in outputSchema", () => {
+    // The TDQS template includes a `**Returns:** \`{ ... }\`` block listing
+    // the response shape. An out-of-date Returns block tells an LLM agent
+    // to plan against fields that don't exist (or omits real ones), which
+    // is exactly the disambiguation rot the rewrite is trying to prevent.
+    // Lock it down by parsing the *top-level* keys from the block and
+    // asserting each appears in the tool's outputSchema.shape. Nested
+    // shapes (e.g. `meta: { has_more, … }`) are out of scope for this
+    // structural check — drift inside a nested object surfaces via the
+    // round-trip test below.
+    //
+    // Tools without a Returns block (or whose block describes a
+    // discriminated/wrapped shape) are skipped here.
+    const topLevelKeys = (body: string): string[] => {
+      const keys: string[] = [];
+      // Sticky regex: anchored to lastIndex, so we walk `body` without
+      // re-slicing on every iteration.
+      const keyRe = /([a-zA-Z_]\w*)\??\s*:/y;
+      let depth = 0;
+      let i = 0;
+      while (i < body.length) {
+        const ch = body[i];
+        if (ch === "{") {
+          depth++;
+          i++;
+          continue;
+        }
+        if (ch === "}") {
+          depth--;
+          i++;
+          continue;
+        }
+        if (depth === 0) {
+          keyRe.lastIndex = i;
+          const m = keyRe.exec(body);
+          if (m) {
+            keys.push(m[1]);
+            i = keyRe.lastIndex;
+            continue;
+          }
+        }
+        i++;
+      }
+      return keys;
+    };
+    for (const tool of tools) {
+      const match = tool.description.match(/\*\*Returns:\*\*\s*`\{([\s\S]+?)\}`/);
+      if (!match) continue;
+      it(`${tool.name} Returns block lists only schema keys`, () => {
+        const claimed = topLevelKeys(match[1]);
+        expect(claimed.length, `${tool.name} Returns block parsed zero keys`).toBeGreaterThan(0);
+        const schemaKeys = new Set(Object.keys(tool.outputSchema.shape));
+        for (const key of claimed) {
+          expect(schemaKeys, `Returns block claims '${key}' but it isn't in ${tool.name}'s outputSchema`).toContain(key);
         }
       });
     }

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -120,14 +120,20 @@ describe("TDQS tool metadata coverage", () => {
       // Skip everything inside a quoted/backticked literal so a prose
       // colon (e.g. `string ("RFC 3339: timestamps")`) doesn't capture
       // the preceding word as a fake key. Tracks the active opener; null
-      // means we're not in a string.
+      // means we're not in a string. Backticks are treated as flat
+      // strings — Returns blocks today don't carry template-literal
+      // `${…}` interpolations, and any future block that does will need
+      // an interpolation-aware extension to this walker.
       let inString: '"' | "'" | "`" | null = null;
       let i = 0;
       while (i < body.length) {
         const ch = body[i];
         if (inString !== null) {
           if (ch === "\\") {
-            // Skip the escaped char so an escaped quote doesn't end the literal.
+            // Skip the escaped char so an escaped quote doesn't end the
+            // literal. Guard against a trailing backslash so `i += 2`
+            // doesn't overshoot — exit cleanly instead.
+            if (i + 1 >= body.length) break;
             i += 2;
             continue;
           }
@@ -197,6 +203,24 @@ describe("TDQS tool metadata coverage", () => {
         }
       });
     }
+  });
+
+  describe("schema describe() and tool description stay aligned", () => {
+    // Defense-in-depth: some hosts surface the schema-level `.describe()`
+    // in argument hints without rendering the tool's overall description.
+    // When a strong factual claim (like "default to active") lives in
+    // both, lock both to a shared substring so a future copy edit can't
+    // drift one without the other.
+    it("list_qurls.status default-active claim appears in both .describe() and the tool description", async () => {
+      const { listQurlsSchema } = await import("../tools/list-qurls.js");
+      const description = tools.find((t) => t.name === "list_qurls")!.description;
+      const statusFieldDescription = listQurlsSchema.shape.status.description ?? "";
+      const sentinel = "active";
+      expect(statusFieldDescription, "list_qurls.status .describe() must mention the active default").toContain(
+        sentinel,
+      );
+      expect(description, "list_qurls description must mention the active default").toContain(sentinel);
+    });
   });
 
   describe("description claims pinned against api-spec defaults", () => {

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -126,7 +126,10 @@ describe("TDQS tool metadata coverage", () => {
           continue;
         }
         if (ch === "}") {
-          depth--;
+          // Clamp at zero. Returns blocks should be balanced, but a
+          // malformed input shouldn't make `depth` go negative and
+          // accidentally re-enter the depth-0 capture branch.
+          depth = Math.max(0, depth - 1);
           i++;
           continue;
         }
@@ -185,7 +188,9 @@ describe("TDQS tool metadata coverage", () => {
       ];
       expect(
         blocks.length,
-        "expected at least one `expires_in: type: string, description: |` block in api-spec/qurls.yaml",
+        "no `expires_in:` block in api-spec/qurls.yaml matched the structural pattern " +
+          "(`type: string` immediately, then `description: |`). If the spec was reordered, " +
+          "added `nullable:`, switched to a quoted scalar, or moved to a $ref, loosen the regex to match.",
       ).toBeGreaterThan(0);
       const blockWithDefault = blocks.find((m) => /Default:\s*\d+\s*[a-z]+/.test(m[1]));
       expect(

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -93,8 +93,11 @@ describe("TDQS tool metadata coverage", () => {
     // Lock it down by parsing the *top-level* keys from the block and
     // asserting each appears in the tool's outputSchema.shape. Nested
     // shapes (e.g. `meta: { has_more, … }`) are out of scope for this
-    // structural check — drift inside a nested object surfaces via the
-    // round-trip test below.
+    // structural check — and not caught by the round-trip test below
+    // either, which validates the handler's structuredContent against
+    // outputSchema (handler ↔ schema), not the description's nested
+    // claims against the schema. A future test could close that gap;
+    // top-level coverage is the bigger lever for now.
     //
     // **One-directional by design.** This enforces description ⊆ schema:
     // a key claimed in the description must exist in the schema. It does
@@ -194,7 +197,7 @@ describe("TDQS tool metadata coverage", () => {
     for (const tool of tools) {
       const body = extractReturnsBody(tool.description);
       if (body === null) continue;
-      it(`${tool.name} Returns block lists only schema keys`, () => {
+      it(`${tool.name} Returns block claims only keys present in schema`, () => {
         const claimed = topLevelKeys(body);
         expect(claimed.length, `${tool.name} Returns block parsed zero keys`).toBeGreaterThan(0);
         const schemaKeys = new Set(Object.keys(tool.outputSchema.shape));
@@ -264,10 +267,15 @@ describe("TDQS tool metadata coverage", () => {
       ).toBeDefined();
       const specDefault = blockWithDefault![1].match(/Default:\s*(\d+\s*[a-z]+)/)![1].trim();
       const description = tools.find((t) => t.name === "create_qurl")!.description;
+      // Require the bolded form (`**24h**`) used in the Behavior beat,
+      // not just the unbolded literal. Bare `24h` also appears in the
+      // `Example:` line, so plain .toContain would silently pass if the
+      // spec moved to e.g. 48h while the example still read '24h'.
+      const claim = `**${specDefault}**`;
       expect(
         description,
-        `create_qurl description must mention the spec's expires_in default '${specDefault}'`,
-      ).toContain(specDefault);
+        `create_qurl Behavior beat must mention the spec's expires_in default as '${claim}'`,
+      ).toContain(claim);
     });
   });
 

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -88,7 +88,7 @@ export function createQurlTool(client: IQURLClient) {
       "**When NOT to use:** use `mint_link` when you already have a resource (`r_…`) and just need an additional access token under it — `create_qurl` always creates a new resource. " +
       "Use `batch_create_qurls` to create many in one round-trip. " +
       "Use `update_qurl` to retag or extend an existing resource without minting a new one. " +
-      "**Behavior:** not idempotent — calling twice produces two distinct resources. " +
+      "**Behavior:** not idempotent — calling twice produces two distinct resources (this tool doesn't surface the underlying API's `Idempotency-Key` header). " +
       "The returned `qurl_link` is shown ONCE in this response and is never recoverable through `get_qurl` or `list_qurls`; persist or share it immediately. " +
       "The newly created resource is in `active` status with the policy and limits applied. " +
       "If `expires_in` is omitted the API defaults to **24h** — do not assume the link is permanent. " +

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -92,7 +92,7 @@ export function createQurlTool(client: IQURLClient) {
       "The returned `qurl_link` is shown ONCE in this response and is never recoverable through `get_qurl` or `list_qurls`; persist or share it immediately. " +
       "The newly created resource is in `active` status with the policy and limits applied. " +
       "If `expires_in` is omitted the API defaults to **24h** — do not assume the link is permanent. " +
-      "**Returns:** `{ qurl_id: string (q_…), resource_id: string (r_…), qurl_link: string (one-time), qurl_site: string, expires_at: string (RFC3339), label?: string }`. " +
+      "**Returns:** `{ qurl_id: string (q_…), resource_id: string (r_…), qurl_link: string (one-time), qurl_site: string, expires_at: string (RFC 3339), label?: string }`. " +
       "`qurl_id` is the only `q_…` display ID an agent gets in this response — keep it if you plan a follow-up against `get_qurl`/`update_qurl`/`mint_link` (which accept either prefix). " +
       "Example: `create_qurl({ target_url: 'https://example.com/private', expires_in: '24h', one_time_use: true, access_policy: { geo_allowlist: ['US'] } })`.",
     inputSchema: createQurlSchema,

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -83,11 +83,17 @@ export function createQurlTool(client: IQURLClient) {
     name: "create_qurl",
     title: "Create qURL",
     description:
-      "Create a new qURL — a policy-bound, expiring access link to a protected target URL. " +
-      "Use this when an agent needs to mint a fresh resource (e.g. share-once link, time-limited access). " +
-      "Use `mint_link` instead when you already have a resource and only need an additional access link. " +
-      "Use `batch_create_qurls` to create many in one call. " +
-      "Returns the new resource ID and a `qurl_link` that is shown ONCE and never returned by `get_qurl` or `list_qurls` — share it immediately.",
+      "Create a new qURL — a policy-bound, expiring access link that gates a target URL with optional IP/geo/UA/AI-agent filters and time or session limits. " +
+      "**When to use:** minting a fresh protected resource for share-once or time-limited access (e.g. send a customer a 24-hour download link, gate a doc behind an IP allowlist, distribute a one-time-use credential to a contractor). " +
+      "**When NOT to use:** use `mint_link` when you already have a resource (`r_…`) and just need an additional access token under it — `create_qurl` always creates a new resource. " +
+      "Use `batch_create_qurls` to create many in one round-trip. " +
+      "Use `update_qurl` to retag or extend an existing resource without minting a new one. " +
+      "**Behavior:** not idempotent — calling twice produces two distinct resources. " +
+      "The returned `qurl_link` is shown ONCE in this response and is never recoverable through `get_qurl` or `list_qurls`; persist or share it immediately. " +
+      "The newly created resource is in `active` status with the policy and limits applied. " +
+      "If `expires_in` is omitted the API applies its account-default expiration — do not assume the link is permanent. " +
+      "**Returns:** `{ resource_id: string (r_…), qurl_link: string (one-time), target_url: string, expires_at: string (RFC3339), status: 'active' }` plus the policy fields you set. " +
+      "Example: `create_qurl({ target_url: 'https://example.com/private', expires_in: '24h', one_time_use: true, access_policy: { geo_allowlist: ['US'] } })`.",
     inputSchema: createQurlSchema,
     outputSchema: createQurlOutputSchema,
     annotations: {

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -92,7 +92,7 @@ export function createQurlTool(client: IQURLClient) {
       "The returned `qurl_link` is shown ONCE in this response and is never recoverable through `get_qurl` or `list_qurls`; persist or share it immediately. " +
       "The newly created resource is in `active` status with the policy and limits applied. " +
       "If `expires_in` is omitted the API defaults to **24h** — do not assume the link is permanent. " +
-      "**Returns:** `{ qurl_id: string (q_…), resource_id: string (r_…), qurl_link: string (one-time), qurl_site: string, expires_at: string (RFC 3339), label?: string }`. " +
+      "**Returns:** `{ qurl_id: string (q_…), resource_id: string (r_…), qurl_link: string (shown once), qurl_site: string, expires_at: string (RFC 3339), label?: string }`. " +
       "`qurl_id` is the only `q_…` display ID an agent gets in this response — keep it if you plan a follow-up against `get_qurl`/`update_qurl`/`mint_link` (which accept either prefix). " +
       "Example: `create_qurl({ target_url: 'https://example.com/private', expires_in: '24h', one_time_use: true, access_policy: { geo_allowlist: ['US'] } })`.",
     inputSchema: createQurlSchema,

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -91,8 +91,9 @@ export function createQurlTool(client: IQURLClient) {
       "**Behavior:** not idempotent — calling twice produces two distinct resources. " +
       "The returned `qurl_link` is shown ONCE in this response and is never recoverable through `get_qurl` or `list_qurls`; persist or share it immediately. " +
       "The newly created resource is in `active` status with the policy and limits applied. " +
-      "If `expires_in` is omitted the API applies its account-default expiration — do not assume the link is permanent. " +
-      "**Returns:** `{ resource_id: string (r_…), qurl_link: string (one-time), target_url: string, expires_at: string (RFC3339), status: 'active' }` plus the policy fields you set. " +
+      "If `expires_in` is omitted the API defaults to **24h** — do not assume the link is permanent. " +
+      "**Returns:** `{ qurl_id: string (q_…), resource_id: string (r_…), qurl_link: string (one-time), qurl_site: string, expires_at: string (RFC3339), label?: string }`. " +
+      "`qurl_id` is the only `q_…` display ID an agent gets in this response — keep it if you plan a follow-up against `get_qurl`/`update_qurl`/`mint_link` (which accept either prefix). " +
       "Example: `create_qurl({ target_url: 'https://example.com/private', expires_in: '24h', one_time_use: true, access_policy: { geo_allowlist: ['US'] } })`.",
     inputSchema: createQurlSchema,
     outputSchema: createQurlOutputSchema,

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -47,7 +47,7 @@ export function listQurlsTool(client: IQURLClient) {
     title: "List qURLs",
     description:
       "List qURL resources, paginated and optionally filtered by status, date range, or search text. " +
-      "**When to use:** discovery — finding qURLs by status (e.g. everything still active), auditing date ranges, or full-text search across descriptions and target URLs. " +
+      "**When to use:** discovery — finding qURLs by status (e.g. everything still active), auditing date ranges, or full-text search across descriptions and target URLs (via the `q` parameter). " +
       "Filters AND together (e.g. `status: 'active'` + `expires_before: '2026-05-01T00:00:00Z'` returns active qURLs about to expire). " +
       "**When NOT to use:** use `get_qurl` instead when you already have a specific resource ID — it returns the same per-resource shape more cheaply and includes the `qurls[]` per-token detail that `list_qurls` omits. " +
       "Use `resolve_qurl` to actually open access to a target URL. " +
@@ -55,8 +55,8 @@ export function listQurlsTool(client: IQURLClient) {
       "An empty `data[]` with `meta.has_more: false` means no resource matched the filters (not an error). " +
       "Pagination is cursor-based: when `meta.has_more` is `true`, pass `meta.next_cursor` as `cursor` on the next call to fetch the following page. " +
       "Default page size is 20, configurable via `limit` up to 100. " +
-      "Pass `status: 'revoked'` to see only revoked qURLs, or `'active,revoked'` to see both. " +
-      "Default sort is `created_at:desc`; override with `sort: 'expires_at:asc'` etc. " +
+      "By default only `active` qURLs are returned; pass `status: 'revoked'` to see only revoked qURLs or `'active,revoked'` to see both. " +
+      "Sort defaults to `created_at:desc` (only the `desc` direction is spec-pinned; the field default is asserted from current API behavior — override with `sort: 'expires_at:asc'` etc.). " +
       "**Returns:** `{ data: QURL[], meta: { has_more: boolean, next_cursor?: string, page_size?: number, request_id?: string } }` — each `data[]` item is the same stable resource shape returned by `get_qurl` minus per-token detail. " +
       'Example: `list_qurls({ status: "active", sort: "expires_at:asc", limit: 10 })` returns the 10 active qURLs expiring soonest.',
     inputSchema: listQurlsSchema,

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -46,14 +46,19 @@ export function listQurlsTool(client: IQURLClient) {
     name: "list_qurls",
     title: "List qURLs",
     description:
-      "List qURL resources, paginated and optionally filtered. " +
-      "Use this to discover qURLs by status (`active`, `revoked`), date range (created_*, expires_*), search text (`q`), or sort order. " +
-      "Use `get_qurl` instead when you already have a specific resource ID. " +
-      "**Pagination:** default page size is 20 (configurable via `limit` up to 100). " +
-      "When the response sets `meta.has_more: true`, pass `meta.next_cursor` as the `cursor` argument on a subsequent call to fetch the next page. " +
-      "**Sorting:** use `sort` like `created_at:desc` (default) or `expires_at:asc`. " +
-      "**Response shape:** `{ data: QURL[], meta: { has_more, next_cursor?, page_size?, request_id? } }` — `data[]` items are the same stable resource shape returned by `get_qurl`, with no per-token detail (call `get_qurl` for `qurls[]`). " +
-      'Example: `list_qurls({ status: "active", sort: "expires_at:asc", limit: 10 })`.',
+      "List qURL resources, paginated and optionally filtered by status, date range, or search text. " +
+      "**When to use:** discovery — finding qURLs by status (e.g. everything still active), auditing date ranges, or full-text search across descriptions and target URLs. " +
+      "Filters AND together (e.g. `status: 'active'` + `expires_before: '2026-05-01T00:00:00Z'` returns active qURLs about to expire). " +
+      "**When NOT to use:** use `get_qurl` instead when you already have a specific resource ID — it returns the same per-resource shape more cheaply and includes the `qurls[]` per-token detail that `list_qurls` omits. " +
+      "Use `resolve_qurl` to actually open access to a target URL. " +
+      "**Behavior:** read-only and idempotent. " +
+      "An empty `data[]` with `meta.has_more: false` means no resource matched the filters (not an error). " +
+      "Pagination is cursor-based: when `meta.has_more` is `true`, pass `meta.next_cursor` as `cursor` on the next call to fetch the following page. " +
+      "Default page size is 20, configurable via `limit` up to 100. " +
+      "By default revoked qURLs are excluded; pass `status: 'revoked'` (or `'active,revoked'`) to include them. " +
+      "Default sort is `created_at:desc`; override with `sort: 'expires_at:asc'` etc. " +
+      "**Returns:** `{ data: QURL[], meta: { has_more: boolean, next_cursor?: string, page_size?: number, request_id?: string } }` — each `data[]` item is the same stable resource shape returned by `get_qurl` minus per-token detail. " +
+      'Example: `list_qurls({ status: "active", sort: "expires_at:asc", limit: 10 })` returns the 10 active qURLs expiring soonest.',
     inputSchema: listQurlsSchema,
     outputSchema: listQurlsOutputSchema,
     annotations: {

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -55,7 +55,7 @@ export function listQurlsTool(client: IQURLClient) {
       "An empty `data[]` with `meta.has_more: false` means no resource matched the filters (not an error). " +
       "Pagination is cursor-based: when `meta.has_more` is `true`, pass `meta.next_cursor` as `cursor` on the next call to fetch the following page. " +
       "Default page size is 20, configurable via `limit` up to 100. " +
-      "Pass `status: 'revoked'` to see only revoked qURLs, or `'active,revoked'` to see both — see `delete_qurl` for the inverse note about how revoked resources surface in this list. " +
+      "Pass `status: 'revoked'` to see only revoked qURLs, or `'active,revoked'` to see both. " +
       "Default sort is `created_at:desc`; override with `sort: 'expires_at:asc'` etc. " +
       "**Returns:** `{ data: QURL[], meta: { has_more: boolean, next_cursor?: string, page_size?: number, request_id?: string } }` — each `data[]` item is the same stable resource shape returned by `get_qurl` minus per-token detail. " +
       'Example: `list_qurls({ status: "active", sort: "expires_at:asc", limit: 10 })` returns the 10 active qURLs expiring soonest.',

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -56,7 +56,12 @@ export function listQurlsTool(client: IQURLClient) {
       "Pagination is cursor-based: when `meta.has_more` is `true`, pass `meta.next_cursor` as `cursor` on the next call to fetch the following page. " +
       "Default page size is 20, configurable via `limit` up to 100. " +
       "By default only `active` qURLs are returned; pass `status: 'revoked'` to see only revoked qURLs or `'active,revoked'` to see both. " +
-      "Sort defaults to `created_at:desc` (only the `desc` direction is spec-pinned; the field default is asserted from current API behavior — override with `sort: 'expires_at:asc'` etc.). " +
+      // The default-active and default-sort-field claims are asserted from
+      // current API behavior; the spec only pins the sort *direction*
+      // default. See issue #99 for spec/staging pinning. The description
+      // intentionally drops the epistemics caveat — overhedging in
+      // LLM-facing prose invites defensive over-specification on every call.
+      "Sort defaults to `created_at:desc`; override with `sort: 'expires_at:asc'` etc. " +
       "**Returns:** `{ data: QURL[], meta: { has_more: boolean, next_cursor?: string, page_size?: number, request_id?: string } }` — each `data[]` item is the same stable resource shape returned by `get_qurl` minus per-token detail. " +
       'Example: `list_qurls({ status: "active", sort: "expires_at:asc", limit: 10 })` returns the 10 active qURLs expiring soonest.',
     inputSchema: listQurlsSchema,

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -17,7 +17,10 @@ export const listQurlsSchema = z.object({
     .string()
     .min(1)
     .optional()
-    .describe("Filter by status (comma-separated, e.g., 'active,revoked')"),
+    .describe(
+      "Filter by status (comma-separated, e.g. 'active,revoked'). " +
+        "Defaults to 'active' when omitted; pass 'revoked' or 'active,revoked' to override.",
+    ),
   created_after: z.string().datetime().optional().describe("Filter: created after this date (RFC 3339)"),
   created_before: z.string().datetime().optional().describe("Filter: created before this date (RFC 3339)"),
   expires_before: z.string().datetime().optional().describe("Filter: expires before this date (RFC 3339)"),

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -55,7 +55,7 @@ export function listQurlsTool(client: IQURLClient) {
       "An empty `data[]` with `meta.has_more: false` means no resource matched the filters (not an error). " +
       "Pagination is cursor-based: when `meta.has_more` is `true`, pass `meta.next_cursor` as `cursor` on the next call to fetch the following page. " +
       "Default page size is 20, configurable via `limit` up to 100. " +
-      "By default revoked qURLs are excluded; pass `status: 'revoked'` (or `'active,revoked'`) to include them. " +
+      "Pass `status: 'revoked'` to see only revoked qURLs, or `'active,revoked'` to see both — see `delete_qurl` for the inverse note about how revoked resources surface in this list. " +
       "Default sort is `created_at:desc`; override with `sort: 'expires_at:asc'` etc. " +
       "**Returns:** `{ data: QURL[], meta: { has_more: boolean, next_cursor?: string, page_size?: number, request_id?: string } }` — each `data[]` item is the same stable resource shape returned by `get_qurl` minus per-token detail. " +
       'Example: `list_qurls({ status: "active", sort: "expires_at:asc", limit: 10 })` returns the 10 active qURLs expiring soonest.',

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -58,12 +58,12 @@ export function listQurlsTool(client: IQURLClient) {
       "An empty `data[]` with `meta.has_more: false` means no resource matched the filters (not an error). " +
       "Pagination is cursor-based: when `meta.has_more` is `true`, pass `meta.next_cursor` as `cursor` on the next call to fetch the following page. " +
       "Default page size is 20, configurable via `limit` up to 100. " +
+      // TODO(#99): both the default-active claim above and the default-sort
+      // claim below are asserted from current API behavior — the spec only
+      // pins the sort *direction* default. The description intentionally
+      // drops the epistemics caveat (overhedging invites defensive
+      // over-specification) and pinning is tracked separately.
       "By default only `active` qURLs are returned; pass `status: 'revoked'` to see only revoked qURLs or `'active,revoked'` to see both. " +
-      // The default-active and default-sort-field claims are asserted from
-      // current API behavior; the spec only pins the sort *direction*
-      // default. See issue #99 for spec/staging pinning. The description
-      // intentionally drops the epistemics caveat — overhedging in
-      // LLM-facing prose invites defensive over-specification on every call.
       "Sort defaults to `created_at:desc`; override with `sort: 'expires_at:asc'` etc. " +
       "**Returns:** `{ data: QURL[], meta: { has_more: boolean, next_cursor?: string, page_size?: number, request_id?: string } }` — each `data[]` item is the same stable resource shape returned by `get_qurl` minus per-token detail. " +
       'Example: `list_qurls({ status: "active", sort: "expires_at:asc", limit: 10 })` returns the 10 active qURLs expiring soonest.',


### PR DESCRIPTION
## Summary
Glama's TDQS panel currently scores `list_qurls` C (2.9/5) and `create_qurl` B (3.3/5). The same three dimensions drag both: **Behavior**, **Completeness**, and **Usage Guidelines**. `delete_qurl` already scores A (3.5) by structuring its description around four explicit beats — Purpose, When-to-use / When-not-to-use, Behavior, Returns. This PR applies that same template to the two lowest-scoring tools as a calibration pilot before a full pass on the remaining seven.

### What changed
- **`list_qurls`** — locks in the AND-semantics of multi-filter queries, the empty-result-vs-error distinction, default revoked-exclusion, and the omitted-`qurls[]` caveat that pushed disambiguation against `get_qurl`.
- **`create_qurl`** — locks in not-idempotent semantics (twice = two resources), the `qurl_link` one-shot rule, the active-status post-state, and the account-default-expiration trap when `expires_in` is omitted.

### Why pilot, not full pass
Cheapest way to verify Glama's rubric responds to the template. If both tools move into A range on the next rescore, we extend to the other seven (`get_qurl`, `resolve_qurl`, `extend_qurl`, `update_qurl`, `mint_link`, `batch_create_qurls`, `delete_qurl` for consistency) and add a structural lint to `tdqs-metadata.test.ts`.

## Test plan
- [x] `npm run build && npm run lint && npm test` — all 373 tests pass.
- [ ] After merge, wait for Glama rescore (or contact Glama to nudge); confirm `list_qurls` and `create_qurl` move from C/B → A on the TDQS panel.
- [ ] If they don't, re-examine the rubric heuristics before extending the rewrite to the other seven tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)