### PR TITLE
ci: gate npm publish on `npm-publish` environment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,7 @@ jobs:
     if: needs.release-please.outputs.release_created
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Adds `environment: npm-publish` to the `publish` job in `release-please.yml`. This is half of a defense-in-depth measure against the TanStack-style supply-chain attack class (GHSA-g7cv-rxg3-hmpx / CVE-2026-45321): a workflow-compromise path that succeeds in invoking the publish job would be blocked at the environment gate before `NPM_TOKEN` or OIDC are exposed.

The `publish-mcp-registry` job already depends on `publish` succeeding, so the same approval transitively gates the registry publish — no separate gate needed.

## What this PR does
- Adds `environment: npm-publish` to the `publish` job.

## What this PR does NOT do (admin follow-up)
The environment doesn't exist yet. After merge, an admin needs to:
1. Settings → Environments → New environment → `npm-publish`
2. Add **Required reviewers** (recommend: a small ops group)
3. Optionally restrict deployment to the `main` branch only

Until step 2 is configured, the workflow change is a no-op — the env auto-creates on first run with no protection.

## Context
Existing supply-chain defenses on this repo:
- `.npmrc` with `min-release-age=7` + `ignore-scripts=true`
- `npm ci` (lockfile-bound) in CI
- `--provenance` on publish (Sigstore-signed)
- Publish checks out the release-please-pushed **tag**, not `main`, so a post-merge commit can't sneak into the tarball
- SHA-pinned actions
- Trigger is `push: branches: [main]` only (no `pull_request_target` path)

This PR adds an out-of-band human gate so even if all the above are bypassed, a publish requires a reviewer click.

## Test plan
- [ ] CI green on this PR
- [ ] Admin: create `npm-publish` environment with required reviewers
- [ ] Verify next release-please-driven publish stalls on environment approval, and that `publish-mcp-registry` waits behind it