### PR TITLE
fix(deps): replace removed z.AnyZodObject with z.ZodObject for zod v4

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -26,8 +26,8 @@ export type ToolFactory = (client: IQURLClient) => {
   name: string;
   title: string;
   description: string;
-  inputSchema: z.AnyZodObject;
-  outputSchema: z.AnyZodObject;
+  inputSchema: z.ZodObject;
+  outputSchema: z.ZodObject;
   annotations: ToolAnnotations;
   // Args vary per tool; exact signatures are validated by registerTool at each call site.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
- `tsc` build on main has been broken since the zod 3.25.76 → 4.4.3 bump in #112 — see [run 26416993091](https://github.com/layervai/qurl-mcp/actions/runs/26416993091).
- Zod v4 removed the v3-era `AnyZodObject` alias. In v4, `ZodObject` itself defaults to a loose shape (`core.$ZodLooseShape`), so it's the right drop-in for the `ToolFactory` contract in `src/server.ts`.
- Two-line type-only change. The runtime call sites (`tool.inputSchema.shape` / `tool.outputSchema.shape`) are unaffected — `.shape` is still on `ZodObject` in v4.

## Test plan
- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] `npm test` passes locally (385/385)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)