### PR TITLE
feat: sync qurl-service API contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Replace `lv_live_xxx` with your actual API key. The key must have the appropriat
 | Tool | Description | Required Scope |
 |------|-------------|----------------|
 | `create_qurl` | Create a secure, policy-bound link to a protected resource | `qurl:write` |
-| `resolve_qurl` | Resolve an access token to get the target URL and open firewall access | `qurl:resolve` |
+| `resolve_qurl` | Resolve an access token to get the target URL and grant network access | `qurl:resolve` |
 | `list_qurls` | List active qURLs with optional pagination | `qurl:read` |
 | `get_qurl` | Get details of a specific qURL by resource ID | `qurl:read` |
 | `delete_qurl` | Revoke a qURL, immediately invalidating the link | `qurl:write` |
@@ -43,6 +43,10 @@ Replace `lv_live_xxx` with your actual API key. The key must have the appropriat
 | `update_qurl` | Update expiration, tags, or description on an active qURL | `qurl:write` |
 | `mint_link` | Mint a new access link for an existing protected resource | `qurl:write` |
 | `batch_create_qurls` | Create multiple qURLs in a single call | `qurl:write` |
+| `revoke_qurl_token` | Revoke one qURL token without revoking sibling tokens on the resource | `qurl:write` |
+| `update_qurl_token` | Update expiry, label, policy, or session limits on one qURL token | `qurl:write` |
+| `list_qurl_sessions` | List active access sessions for a qURL resource | `qurl:read` |
+| `terminate_qurl_sessions` | Terminate one or all active sessions for a qURL resource | `qurl:write` |
 
 ## Available Resources
 

--- a/api-spec/qurls.yaml
+++ b/api-spec/qurls.yaml
@@ -1,23 +1,33 @@
 # OpenAPI 3.0.3 is used instead of 3.1.0 for compatibility with oapi-codegen.
 # oapi-codegen v2.x does not fully support OpenAPI 3.1 features.
+#
+# This spec drives the customer-facing API reference (Scalar). Before
+# adding or editing any rendered string (description, summary, example,
+# enum labels, tag/server/info fields), read the "Audience: openapi.yaml
+# is customer-facing" section in docs/claude/api-codegen.md. Do not
+# leak internal implementation (AWS primitives, DynamoDB internals,
+# internal hostnames, middleware names, internal repo refs, deployment
+# codenames).
 openapi: 3.0.3
 info:
-  title: QURL Service API
+  title: qURL™ Service API
   description: |
-    API for managing QURL resources - secure, time-limited access links to protected resources.
+    API for managing qURL resources — secure, time-limited access links to protected resources.
+
+    **Quantum URL (qURL)** · The internet has a hidden layer. This is how you enter.
 
     ## Authentication
     The public API requires Auth0 JWT tokens or API keys with appropriate scopes:
-    - `qurl:read` - Read access to QURLs and quota
-    - `qurl:write` - Create, update, and delete QURLs
-    - `qurl:resolve` - Resolve access tokens and trigger firewall access (headless)
+    - `qurl:read` - Read access to qURLs and quota
+    - `qurl:write` - Create, update, and delete qURLs
+    - `qurl:resolve` - Resolve access tokens and grant network access (headless)
+    - `qurl:agent` - Bootstrap LayerV qURL Connector agents (POST /v1/agent/bootstrap)
     - `qurl:write` also covers webhook management
 
     ## Rate Limiting
-    - Per-owner: Configurable limit (default varies by plan)
-    - Per-IP: Configurable limit for internal endpoints
 
-    Rate limit exceeded responses include a `Retry-After` header.
+    Per-owner limits are configurable and vary by plan. Rate-limit
+    exceeded responses include a `Retry-After` header.
 
     ## Idempotency
     Mutating endpoints (POST, PUT, PATCH) support idempotency via the `Idempotency-Key` header.
@@ -61,6 +71,18 @@ info:
     GET endpoints support ETag-based caching. Include `If-None-Match` header with
     the ETag value to receive a 304 Not Modified response when content hasn't changed.
 
+    ## Object Model
+
+    - **Resource** (`r_` prefix): Long-lived container grouped by target URL. Holds metadata
+      (tags, description, custom domain). Auto-created on first qURL for a target URL.
+    - **qURL / Access Token** (`q_` display ID, `at_` token): Short-lived, policy-bound access
+      token. Belongs to one Resource. Owns expiry, access policy, session limits.
+    - **Access Link**: The `qurl.link/at_xxx` URL returned once at creation time.
+
+    The `/v1/qurls` endpoints are resource-centric — `{id}` accepts both resource IDs (`r_`)
+    and qURL display IDs (`q_`). Per-qURL management uses
+    `DELETE /v1/resources/{id}/qurls/{qurl_id}` to revoke individual tokens.
+
     ## Webhooks
     Subscribe to events via webhook endpoints. Webhook payloads are signed with
     HMAC-SHA256 using your webhook secret. Verify the `QURL-Signature` header.
@@ -80,7 +102,7 @@ security:
 
 tags:
   - name: QURLs
-    description: QURL resource management
+    description: qURL resource management
   - name: Quota
     description: Usage quota information
   - name: Webhooks
@@ -94,29 +116,35 @@ tags:
   - name: Billing
     description: Stripe checkout, portal, and invoices (JWT-only)
   - name: Resolution
-    description: Headless QURL resolution for AI agents and programmatic clients
+    description: Headless qURL resolution for AI agents and programmatic clients
   - name: Domains
     description: Custom domain management (enterprise plan)
   - name: Access Codes
     description: Access code management for protected resource sharing
   - name: Resources
-    description: Resource management (dashboard-only, groups QURLs by target URL)
+    description: Resource management — groups qURLs by target URL
+  - name: Connectors
+    description: Plugin connections that let qURL mint and report on resources owned by external workspaces, guilds, and systems.
+  - name: Agent
+    description: Bootstrap endpoint for the LayerV qURL Connector agent
+  - name: Sessions
+    description: Active access-session inspection and termination for a resource
 
 paths:
   /v1/resolve:
     post:
       tags:
         - Resolution
-      summary: Resolve a QURL access token (headless)
+      summary: Resolve a qURL access token (headless)
       description: |
-        Resolves a QURL access token and triggers an NHP knock to open firewall access
+        Resolves a qURL access token and triggers an NHP knock to grant network access
         for the caller's IP address. Returns the target URL that the caller can access
         directly for the duration of the access grant.
 
         This endpoint is designed for AI agents and programmatic clients that cannot
-        follow the browser-based QURL flow.
+        follow the browser-based qURL flow.
 
-        **Important:** The firewall is opened for the IP address making this request.
+        **Important:** Access is granted to the IP address making this request.
         The `src_ip` in the response reflects which IP was granted access.
 
         **One-time tokens:** If the token is one-time-use and the NHP knock fails after
@@ -137,7 +165,7 @@ paths:
               access_token: "at_k8xqp9h2sj9lx7r4abcdef"
       responses:
         '200':
-          description: Token resolved and firewall access granted
+          description: Token resolved and network access granted
           content:
             application/json:
               schema:
@@ -169,12 +197,120 @@ paths:
         '502':
           $ref: '#/components/responses/BadGateway'
 
+  /v1/agent/bootstrap:
+    post:
+      tags:
+        - Agent
+      summary: Bootstrap a LayerV qURL Connector agent
+      description: |
+        Registers a LayerV agent's X25519 public key and returns the
+        NHP peer info the agent needs to perform its first knock.
+
+        Re-bootstrapping with a new `public_key` for the same
+        `agent_id` is idempotent (key rotation).
+
+        **Authentication:** API key with the `qurl:agent` scope. JWTs
+        are rejected with 403.
+
+        **Rate limit:** 10 per hour per API key.
+
+        **Audit:** every outcome is recorded.
+      operationId: postV1AgentBootstrap
+      security:
+        - bearerAuth: [qurl:agent]
+      # Operation-level `servers:` declares the customer-facing
+      # canonical hosts for this operation. Scalar and other OpenAPI
+      # 3.0.x renderers honor op-level Servers (they OVERRIDE the root
+      # `servers:` block for the specific operation's docs render), so
+      # customers reading the API reference see "POST /v1/agent/bootstrap
+      # on bootstrap.layerv.{ai,xyz}" — matching the customer install
+      # guidance (qurl-reverse-tunnel-client's docs/install-docker.md
+      # directs sidecars to bootstrap.layerv.*).
+      #
+      # Runtime caveat: kin-openapi v0.135 (`routers/gorillamux/
+      # router.go:53-65`) SILENTLY IGNORES op-level Servers for
+      # request matching. The validator only consults root-level
+      # (api.layerv.*) and path-item-level. We deliberately don't use
+      # path-item-level here because that triggers a leak bug in the
+      # same router file (`servers, err = makeServers(...)` mutates a
+      # shared variable, so the path-level Servers leak forward to
+      # every subsequent path in InMatchingOrder, 404ing them from
+      # api.layerv.*).
+      #
+      # Workaround: `middleware.RewriteBootstrapHostForValidator`
+      # (mounted before the validator in router.go) rewrites the
+      # request URL.Host from `bootstrap.layerv.<tld>` to
+      # `api.layerv.<tld>` when the path is /v1/agent/bootstrap, so
+      # the validator's root-Servers match passes. The handler runs
+      # unchanged. Once kin-openapi v0.135's op-level Servers
+      # behavior is fixed upstream, the middleware can be removed
+      # and this op-level block becomes the runtime gate.
+      servers:
+        - url: https://bootstrap.layerv.ai
+          description: Production bootstrap endpoint
+        - url: https://bootstrap.layerv.xyz
+          description: Sandbox bootstrap endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentBootstrapRequest'
+            example:
+              public_key: "62cFrVBeF1Tl7lUAJ9MNa9lFykVf6D7mNqLaEYggFN0="
+              agent_id: "prod-us-east-1"
+              hostname: "agent-7f8c9b-prod-use1"
+              version: "1.4.2"
+      responses:
+        '200':
+          description: Agent registered.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentBootstrapResponse'
+              example:
+                data:
+                  agent_id: "prod-us-east-1"
+                  registered_at: "2026-05-10T15:30:00Z"
+                  nhp_server_peer:
+                    public_key_b64: "EqHTVFh6t5DUK1aA2nkq82x5HLRqrO6FPqxcwSfKCl8="
+                    host: "nhp.layerv.ai"
+                    port: 62206
+                    expire_time: 0
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: |
+            Concurrent registration conflict for the same `agent_id`.
+
+            **Retry**: re-issue the same request body with exponential
+            backoff (e.g., 1s / 4s / 16s, capped at 60s). Registration
+            is idempotent on `agent_id`, so resending the same
+            `public_key` is safe. Do NOT regenerate the keypair on
+            409.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /v1/qurls:
     post:
       tags:
         - QURLs
-      summary: Create a new QURL
-      description: Creates a new QURL resource that provides secure access to a target URL.
+      summary: Create a new qURL
+      description: |
+        Creates a qURL access token for a target URL. Auto-creates a resource
+        if none exists for the target URL.
       operationId: createQurl
       security:
         - bearerAuth: [qurl:write]
@@ -202,10 +338,10 @@ paths:
                   deny_categories: ["gptbot", "commoncrawl", "bytedance"]
       responses:
         '201':
-          description: QURL created successfully
+          description: qURL created successfully
           headers:
             Location:
-              description: URL of the created QURL resource
+              description: URL of the created qURL resource
               schema:
                 type: string
                 format: uri
@@ -232,6 +368,27 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '409':
+          description: |
+            An active resource already exists for this `target_url`
+            with a different `type`. Returned with code
+            `resource_type_conflict`. Resolve by using the existing
+            resource's id (mint via `POST /v1/resources/{id}/qurls`),
+            by tombstoning the existing resource, or by submitting a
+            new `target_url`.
+
+            > **Note — idempotency cache.** The idempotency cache
+            > stores 409 responses under the request's
+            > `Idempotency-Key` for the standard 24-hour TTL. A caller
+            > that hits this 409, remediates the conflict (e.g. by
+            > tombstoning the existing resource), and retries with the
+            > *same* `Idempotency-Key` will receive the cached 409
+            > rather than a fresh evaluation. **Use a new
+            > `Idempotency-Key` on the post-remediation retry.**
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
         '429':
           $ref: '#/components/responses/RateLimitExceeded'
         '500':
@@ -239,9 +396,10 @@ paths:
     get:
       tags:
         - QURLs
-      summary: List QURLs
+      summary: List qURLs
       description: |
-        Lists QURL resources owned by the authenticated user.
+        Lists resources owned by the authenticated user. Each resource groups
+        qURLs sharing the same target URL.
         Supports filtering by status and date ranges, with cursor-based pagination.
       operationId: listQurls
       security:
@@ -264,10 +422,14 @@ paths:
             type: string
         - name: status
           in: query
-          description: Filter by status (comma-separated for multiple)
+          description: |
+            Filter by status. Valid values are `active` and `revoked`;
+            multiple values may be supplied as a comma-separated list.
+            Invalid values are rejected by the handler with the standard
+            invalid_filter error envelope.
           schema:
             type: string
-            example: "active,revoked"
+            example: active,revoked
         - name: created_after
           in: query
           description: Filter by creation date (RFC3339)
@@ -313,7 +475,7 @@ paths:
             example: "dashboard"
       responses:
         '200':
-          description: List of QURLs
+          description: List of qURLs
           headers:
             ETag:
               description: Entity tag for caching
@@ -358,8 +520,8 @@ paths:
     get:
       tags:
         - QURLs
-      summary: Get a QURL
-      description: Retrieves a single QURL resource by ID.
+      summary: Get a qURL
+      description: Retrieves a resource and its qURL tokens by resource or qURL display ID.
       operationId: getQurl
       security:
         - bearerAuth: [qurl:read]
@@ -367,7 +529,7 @@ paths:
         - $ref: '#/components/parameters/QurlId'
       responses:
         '200':
-          description: QURL details
+          description: qURL details
           headers:
             ETag:
               description: Entity tag for caching
@@ -404,8 +566,10 @@ paths:
     delete:
       tags:
         - QURLs
-      summary: Delete a QURL
-      description: Revokes a QURL resource (soft delete).
+      summary: Delete a qURL
+      description: |
+        Revokes a resource and all its qURLs. Requires a resource ID (r_ prefix).
+        To revoke a single token, use DELETE /v1/resources/{resource_id}/qurls/{qurl_id}.
       operationId: deleteQurl
       security:
         - bearerAuth: [qurl:write]
@@ -413,7 +577,7 @@ paths:
         - $ref: '#/components/parameters/QurlId'
       responses:
         '204':
-          description: QURL deleted successfully
+          description: qURL deleted successfully
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -428,8 +592,8 @@ paths:
     patch:
       tags:
         - QURLs
-      summary: Update a QURL
-      description: Updates a QURL resource. Can extend expiration and/or update tags and description.
+      summary: Update a qURL
+      description: Updates resource-level metadata (description, tags, expiration).
       operationId: updateQurl
       security:
         - bearerAuth: [qurl:write]
@@ -453,7 +617,7 @@ paths:
                   expires_at: "2024-01-22T10:30:00Z"
       responses:
         '200':
-          description: QURL updated successfully
+          description: qURL updated successfully
           content:
             application/json:
               schema:
@@ -475,7 +639,7 @@ paths:
         - QURLs
       summary: Mint an access link
       description: |
-        Creates a single-use access link for a QURL resource.
+        Creates a new qURL access token for an existing resource.
         The link can be shared with users who need temporary access to the resource.
       operationId: mintLink
       security:
@@ -484,6 +648,7 @@ paths:
         - $ref: '#/components/parameters/QurlId'
         - $ref: '#/components/parameters/IdempotencyKey'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -527,9 +692,9 @@ paths:
     post:
       tags:
         - QURLs
-      summary: Batch create QURLs
+      summary: Batch create qURLs
       description: |
-        Creates multiple QURL resources in a single request.
+        Creates multiple qURL resources in a single request.
         Returns 201 if all succeed, 207 Multi-Status if mixed results, or 400 if all fail.
 
         **Validation is atomic:** if any item fails input validation (e.g. invalid tags,
@@ -558,7 +723,7 @@ paths:
                   one_time_use: true
       responses:
         '201':
-          description: All QURLs created successfully
+          description: All qURLs created successfully
           content:
             application/json:
               schema:
@@ -583,7 +748,22 @@ paths:
                 meta:
                   request_id: "req_abc123"
         '207':
-          description: Mixed results (some succeeded, some failed)
+          description: |
+            Mixed results (some succeeded, some failed). Per-item
+            failures carry a `code` field SDK consumers can branch on.
+            Today the per-item codes are:
+              - `resource_type_conflict` — the item's `target_url`
+                already has an active resource of a different `type`
+                for the same owner. Mirrors the single-item
+                `POST /v1/qurls` 409 surface. Remediate by re-submitting
+                against the existing resource's id (mint via
+                `POST /v1/resources/{id}/qurls`), tombstoning the
+                existing resource, or sending a new `target_url`.
+              - `creation_failed` — every other per-item failure
+                (validation rejections, quota, transient repo errors).
+                The `message` field carries the human-readable detail;
+                structured codes for the failure kinds bucketed here
+                are tracked as a future enhancement.
           content:
             application/json:
               schema:
@@ -602,12 +782,22 @@ paths:
                     - index: 1
                       success: false
                       error:
-                        code: "invalid_target_url"
-                        message: "target_url must be a valid HTTPS URL"
+                        code: "resource_type_conflict"
+                        message: "existing resource for this target_url has a different type"
+                    - index: 2
+                      success: false
+                      error:
+                        code: "creation_failed"
+                        message: "invalid expires_in format"
                 meta:
                   request_id: "req_abc123"
         '400':
-          description: All items failed or invalid request
+          description: |
+            All items failed or invalid request. Per-item `code` field
+            on each failed item carries the same vocabulary as the 207
+            response (`resource_type_conflict` or `creation_failed`).
+            SDK consumers should branch on per-item codes rather than
+            the outer HTTP status.
           content:
             application/json:
               schema:
@@ -627,10 +817,43 @@ paths:
         - Resources
       summary: List resources
       description: |
-        Lists all resources (target URL groupings) for the authenticated user.
-        Each resource groups QURLs that share the same target URL. The response
-        includes a `qurl_count` for each resource showing how many active QURLs
-        exist for it. Use GET /v1/resources/{id} to see the individual QURLs.
+        Lists resources (target URL groupings) for the authenticated user.
+        Each resource groups qURLs that share the same target URL. The response
+        includes a `qurl_count` for each resource showing how many qURL token
+        rows exist for it, including revoked or expired rows still awaiting
+        background TTL cleanup. Use GET /v1/resources/{id} to see a bounded
+        preview of individual qURLs.
+
+        **Filtering by alias:** pass `?alias={alias}` to look up a specific
+        owner-scoped alias. Returns a list of 0 or 1 items. An empty
+        list means the caller does not own a resource with that alias
+        (tenant-isolated: aliases for other owners are not visible).
+        Reserved-word and format errors on the `alias` query surface as
+        `400 alias_reserved` / `400 alias_invalid_format`. When `alias` is
+        supplied, `cursor` / `limit` are ignored (the result is bounded by
+        the per-owner alias uniqueness invariant). Alias lookup is mutually
+        exclusive with `slug`, `status`, and `type`.
+
+        **Filtering by tunnel slug:** pass `?slug={slug}` to look up a
+        specific owner-scoped tunnel resource by immutable sidecar slug.
+        Returns a list of 0 or 1 active tunnel resources. Alias and slug
+        filters are mutually exclusive, and slug lookup cannot be combined
+        with `status` or `type`. Restricted `purpose=tunnel_bootstrap` API
+        keys cannot use this read path; sidecars should use the
+        idempotent `POST /v1/resources` find-or-create flow for their bound
+        slug.
+
+        **Filtering by type:** pass `?type=url` for target-URL resources
+        or `?type=tunnel` for qURL Connector resources. `transit`
+        (connector-owned) resources are intentionally not listed here; use the
+        connector installation endpoints for connector reporting.
+
+        Pagination cursors on paginated list paths are scoped to the
+        `type` / `status` filter set that produced them. Reusing a cursor
+        with different `type` or `status` filters returns
+        `400 invalid_request`; restart pagination when changing filters.
+        Alias and slug filters are bounded point lookups and ignore
+        `cursor` / `limit`.
       operationId: listResources
       security:
         - bearerAuth: []
@@ -648,6 +871,58 @@ paths:
             minimum: 1
             maximum: 100
             default: 20
+        - name: alias
+          in: query
+          description: |
+            Filter to a single resource by owner-scoped alias. Same format
+            as `CreateResourceRequest.alias` — 3–64 chars, must start with
+            a lowercase letter, end alphanumeric, hyphens allowed inside.
+            Tenant-isolated: only resources owned by the authenticated
+            caller are visible, so the same alias string can resolve for
+            two different callers without collision. Mutually exclusive with
+            `slug`, `status`, and `type`; when supplied, `cursor` / `limit`
+            are ignored.
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 64
+            pattern: '^[a-z][a-z0-9-]{1,62}[a-z0-9]$'
+        - name: slug
+          in: query
+          description: |
+            Filter to a single active tunnel resource by owner-scoped immutable
+            slug. Same format as `CreateResourceRequest.slug` — 3–64 chars,
+            must start with a lowercase letter, end alphanumeric, hyphens
+            allowed inside. Tenant-isolated: only resources owned by the
+            authenticated caller are visible. Mutually exclusive with `alias`,
+            `status`, and `type`; when supplied, `cursor` / `limit` are
+            ignored.
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 64
+            pattern: '^[a-z][a-z0-9-]{1,62}[a-z0-9]$'
+        - name: status
+          in: query
+          description: |
+            Filter by resource status. Use `active`, `revoked`, or a
+            comma-separated combination without spaces. Invalid values are
+            rejected by the handler with the standard invalid_filter error
+            envelope.
+          schema:
+            type: string
+            pattern: '^(active|revoked)(,(active|revoked))*$'
+            example: active,revoked
+        - name: type
+          in: query
+          description: |
+            Filter resource list rows by dashboard resource type. Supported
+            values are `url` and `tunnel`. Connector-owned resources are
+            intentionally surfaced through `/v1/connectors/installations`
+            instead of this resource list.
+          schema:
+            type: string
+            enum: [url, tunnel]
       responses:
         '200':
           description: Resource list
@@ -667,8 +942,33 @@ paths:
       summary: Create resource
       description: |
         Explicitly create a resource (register a target URL before creating
-        QURLs for it). If a resource already exists for the same target URL
+        qURLs for it). If a resource already exists for the same target URL
         and owner, the existing resource is returned (idempotent).
+
+        **Type must match the existing row.** Dedup matches on
+        `(owner, target_url)`. If a row already exists for that pair
+        and your `type` disagrees with it, the server returns
+        `409 resource_type_conflict` rather than silently surfacing
+        the existing row — `url` and `transit` have different read-
+        side redaction guarantees, and inheriting the wrong one
+        would invert the caller's privacy expectations. Same-`type`
+        duplicates remain idempotent. Full table is in the
+        `CreateResourceRequest` schema.
+
+        Alias semantics on POST (full rules in the `CreateResourceRequest`
+        schema description):
+
+          - New resource + new alias: creates and binds.
+          - Idempotent: same target URL + matching alias (or no alias)
+            returns the existing resource.
+          - 409 `resource_alias_mismatch`: same target URL but the
+            request supplies an alias that disagrees with the existing
+            binding (including "supplies an alias when the existing
+            resource has none"). Remediation: use `PATCH
+            /v1/resources/{id}` with `alias` to set or rebind.
+          - 409 `alias_in_use`: the alias is already claimed by another
+            of your resources (sentinel collision). Remediation: pick
+            a different alias.
       operationId: createResource
       security:
         - bearerAuth: []
@@ -681,10 +981,108 @@ paths:
       responses:
         '201':
           description: Resource created
+          headers:
+            Location:
+              description: |
+                Canonical URL of the created resource (RFC 7231 §7.1.2).
+                Mirrors `POST /v1/qurls` so resource-create has parity
+                with qURL-create and SDKs can read the new resource's
+                URL from a single header rather than re-construct it
+                from the response body.
+              schema:
+                type: string
+                format: uri
+                example: "https://api.qurl.link/v1/resources/r_k8xqp9h2sj9"
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResourceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: |
+            Returned with one of three distinct error codes:
+
+              - `alias_in_use`: the alias is already claimed by another
+                resource owned by the caller (sentinel collision).
+                Remediation: pick a different alias, or release the
+                conflict via `PATCH alias: null` / `DELETE` on the
+                owning resource.
+              - `resource_alias_mismatch`: the request's `target_url`
+                resolves to an existing resource whose alias disagrees
+                with the request (or that has no alias while the
+                request supplies one). The endpoint refuses to silently
+                rebind on what looks like an idempotent create.
+                Remediation: rebind explicitly via `PATCH
+                /v1/resources/{id}`.
+              - `resource_type_conflict`: the request's `target_url`
+                resolves to an existing resource whose `type` disagrees
+                with the request. The endpoint refuses to silently
+                surface a row of the wrong type because the read-side
+                redaction contract differs by `type`. Remediation:
+                `type` is immutable on an existing resource (PATCH
+                cannot retype). Either reuse the existing row as-is,
+                or revoke it via `DELETE /v1/resources/{id}` and retry
+                with the desired `type`. See the cross-type idempotency
+                block on `CreateResourceRequest` for the full table.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '410':
+          description: |
+            Returned by the tunnel `find_or_create` flow when the
+            supplied `slug` resolves to a tombstoned resource. The body
+            carries the standard problem-details envelope plus
+            `meta.tombstone` when the tombstone metadata can be loaded.
+            Delete the tombstoned resource or choose a fresh slug before
+            retrying.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/connectors/installations:
+    get:
+      tags:
+        - Connectors
+      summary: List connector installations
+      description: |
+        Lists normalized connector installations for the authenticated
+        customer. Connector plugins own platform-specific state such as
+        Slack workspaces, Discord guilds, or storage buckets; this endpoint
+        provides the dashboard with a stable, plugin-neutral summary. Connector
+        data may be eventually consistent with qURL resource activity.
+      operationId: listConnectorInstallations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: cursor
+          in: query
+          description: Pagination cursor from a previous response
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of items to return (1-100, default 20)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Connector installation list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorInstallationListResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -706,9 +1104,9 @@ paths:
         - Resources
       summary: Get resource details
       description: |
-        Get resource details including all QURLs associated with it.
-        Each QURL has its own label, expiry, access policy, and NHP
-        firewall rules — independent of other QURLs on the same resource.
+        Get resource details including all qURLs associated with it.
+        Each qURL has its own label, expiry, access policy, and NHP
+        access rules — independent of other qURLs on the same resource.
       operationId: getResource
       security:
         - bearerAuth: []
@@ -723,13 +1121,51 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '410':
+          description: |
+            Resource lifecycle has closed and the resource is no
+            longer mintable. The body carries the standard
+            problem-details envelope plus a `meta.tombstone` field
+            with the read-only audit trail. The resource will be
+            hard-deleted after the tombstone retention window
+            expires; until then this metadata remains queryable
+            via GET.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
         '500':
           $ref: '#/components/responses/InternalServerError'
     patch:
       tags:
         - Resources
       summary: Update resource metadata
-      description: Update resource metadata (tags, description, custom_domain).
+      description: |
+        Update resource metadata (tags, description, preserve_host,
+        custom_domain, alias).
+
+        **Alias semantics (RFC 7396 JSON Merge Patch):** the `alias`
+        field is tri-valued — omit for no change, send a string to
+        set or rebind, send `null` to clear the existing alias and
+        release the uniqueness sentinel.
+
+        **Atomicity:** all field writes within a single PATCH commit
+        atomically — the resource never lands in a partial state where
+        some fields applied and others did not. The alias-mutation
+        path is the implementation tripwire: an alias write touches
+        two rows (the resource row and a `(owner_id, alias)`
+        uniqueness-sentinel row), and both writes — plus any `tags` /
+        `description` / `preserve_host` fields in the same body —
+        bundle into a single `TransactWriteItems` so a `409
+        alias_in_use` rolls the whole PATCH back.
+
+        **`custom_domain` exclusion:** `custom_domain` set/clear runs
+        external DNS verification and a uniqueness query that don't
+        fold into the alias transaction. To preserve atomicity,
+        `custom_domain` and any alias mutation are mutually exclusive
+        in the same PATCH (returns `400 mutually_exclusive_fields`).
+        Issue the two mutations as separate PATCH requests when both
+        are needed.
       operationId: updateResource
       security:
         - bearerAuth: []
@@ -752,14 +1188,37 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: |
+            Alias already in use by another resource. The entire PATCH
+            is rolled back — all fields sent in the same request are
+            NOT persisted.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '410':
+          description: |
+            Resource is tombstoned and rejects mutations. The
+            resource's lifecycle has closed; mutating fields like
+            description/tags/custom_domain/alias post-tombstone would
+            silently change the audit-trail metadata a customer reads
+            back via `meta.tombstone`. Body MAY carry the tombstone
+            metadata in `meta.tombstone`; the field is absent on the
+            rare re-fetch race path (defensive SDKs should treat
+            presence as optional).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
       tags:
         - Resources
-      summary: Revoke resource and all its QURLs
+      summary: Revoke resource and all its qURLs
       description: |
-        Revokes a resource. All QURLs associated with the resource become
+        Revokes a resource. All qURLs associated with the resource become
         inaccessible because token resolution checks the resource status.
       operationId: deleteResource
       security:
@@ -771,6 +1230,116 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/resources/{id}/qurls:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Resource ID
+        schema:
+          type: string
+          pattern: '^r_[a-z0-9_-]{11}$'
+    post:
+      tags:
+        - Resources
+      summary: Mint a qURL against an existing resource
+      description: |
+        Creates a new qURL against the resource identified by `{id}`.
+        Use this endpoint when you already have a resource ID; use
+        `POST /v1/qurls` to create a qURL from a `target_url` directly.
+
+        A request body is required, but every field inside it is
+        optional — to mint with the owner's plan defaults, send `{}`.
+        (The body is required at the wire level so empty `POST`s are
+        rejected with a clear validation error rather than silently
+        succeeding.)
+
+        Status hierarchy:
+
+          - 404 `resource_not_found` if no resource with this ID exists.
+          - 403 `access_denied` if the resource exists but belongs to
+            another owner.
+          - 403 `tunnel_disabled` if the resource is a tunnel and
+            tunnel minting is currently unavailable.
+          - 400 `revoked` if the resource is revoked.
+          - 400 `invalid_input` for malformed or out-of-range field
+            values (e.g. a `session_duration` like `5x`).
+          - 400 `invalid_session_duration` if `session_duration` exceeds
+            the resource's cap.
+      operationId: createQurlForResource
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      # required: true matches wire-level reality — oapi-codegen's strict
+      # server binds the request body unconditionally, so a literal empty
+      # body returns 400 at the bind step. Accept-all-defaults is still
+      # one keystroke: send `{}`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateQurlForResourceRequest'
+            example:
+              expires_in: "7d"
+              max_sessions: 5
+              access_policy:
+                ip_allowlist: ["192.168.1.0/24"]
+                geo_allowlist: ["US", "CA"]
+              label: "Alice from Acme"
+      responses:
+        '201':
+          description: qURL created successfully
+          headers:
+            Location:
+              description: URL of the created qURL resource
+              schema:
+                type: string
+                format: uri
+                example: "https://api.qurl.link/v1/qurls/r_k8xqp9h2sj9"
+            Idempotency-Replayed:
+              description: Present and set to "true" if response was replayed from cache
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateQurlResponse'
+              example:
+                data:
+                  resource_id: "r_k8xqp9h2sj9"
+                  qurl_link: "https://qurl.link/#at_k8xqp9h2sj9lx7r4abcdef"
+                  qurl_site: "https://r_k8xqp9h2sj9.qurl.site"
+                  expires_at: "2024-01-15T10:30:00Z"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '410':
+          description: |
+            Resource lifecycle has closed and rejects new qURL
+            mints. Cannot mint new qURLs against this resource;
+            create a fresh resource for a new target if needed.
+            Body MAY carry `meta.tombstone` with the read-only
+            audit trail; the field is absent on the rare
+            consistency-race path (defensive SDKs should treat
+            presence as optional).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -786,29 +1355,29 @@ paths:
       - name: qurl_id
         in: path
         required: true
-        description: QURL display ID (q_ + 11 hex chars)
+        description: qURL display ID (q_ + 11 hex chars)
         schema:
           type: string
           pattern: '^q_[0-9a-f]{11}$'
     delete:
       tags:
         - Resources
-      summary: Revoke a specific QURL
+      summary: Revoke a specific qURL
       description: |
-        Revokes a specific QURL token. The QURL must be active. Other QURLs
+        Revokes a specific qURL token. The qURL must be active. Other qURLs
         on the same resource are not affected.
       operationId: revokeResourceQurl
       security:
         - bearerAuth: []
       responses:
         '204':
-          description: QURL revoked
+          description: qURL revoked
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          description: QURL is not active
+          description: qURL is not active
           content:
             application/problem+json:
               schema:
@@ -818,10 +1387,10 @@ paths:
     patch:
       tags:
         - Resources
-      summary: Update a specific QURL
+      summary: Update a specific qURL
       description: |
-        Update expiry, label, access policy, or max_sessions on a specific QURL token.
-        The QURL must be active. At least one field must be provided.
+        Update expiry, label, access policy, or max_sessions on a specific qURL token.
+        The qURL must be active. At least one field must be provided.
       operationId: updateResourceQurl
       security:
         - bearerAuth: []
@@ -833,7 +1402,7 @@ paths:
               $ref: '#/components/schemas/UpdateQurlTokenRequest'
       responses:
         '200':
-          description: QURL updated
+          description: qURL updated
           content:
             application/json:
               schema:
@@ -845,7 +1414,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          description: QURL is not active
+          description: qURL is not active
           content:
             application/problem+json:
               schema:
@@ -861,12 +1430,12 @@ paths:
       summary: List active sessions for a resource
       description: Returns all active access sessions for the specified resource.
       security:
-        - bearerAuth: []
-        - apiKeyAuth: []
+        - bearerAuth: [qurl:read]
       parameters:
         - name: id
           in: path
           required: true
+          description: Resource ID (r_ prefix)
           schema:
             type: string
       responses:
@@ -889,12 +1458,12 @@ paths:
       summary: Terminate all active sessions for a resource
       description: Immediately terminates all active sessions for the specified resource.
       security:
-        - bearerAuth: []
-        - apiKeyAuth: []
+        - bearerAuth: [qurl:write]
       parameters:
         - name: id
           in: path
           required: true
+          description: Resource ID (r_ prefix)
           schema:
             type: string
       responses:
@@ -919,17 +1488,18 @@ paths:
       summary: Terminate a specific session
       description: Immediately terminates a specific active session.
       security:
-        - bearerAuth: []
-        - apiKeyAuth: []
+        - bearerAuth: [qurl:write]
       parameters:
         - name: id
           in: path
           required: true
+          description: Resource ID (r_ prefix)
           schema:
             type: string
         - name: session_id
           in: path
           required: true
+          description: Session ID to terminate
           schema:
             type: string
       responses:
@@ -999,7 +1569,7 @@ paths:
       summary: Get current billing period usage
       description: |
         Returns usage statistics for the current billing period, including
-        the number of QURLs created, the user's tier, period dates, and a
+        the number of qURLs created, the user's tier, period dates, and a
         cost estimate for usage-based plans (Growth tier).
         Requires JWT authentication (dashboard endpoint).
       operationId: getUsageCurrentPeriod
@@ -1022,7 +1592,7 @@ paths:
                   cost_estimate:
                     currency: "usd"
                     amount_cents: 1500
-                    description: "150 QURLs x $0.10/QURL"
+                    description: "150 qURLs x $0.10/qURL"
                 meta:
                   request_id: "req_abc123"
         '401':
@@ -1040,7 +1610,7 @@ paths:
         - Usage
       summary: Get daily usage breakdown
       description: |
-        Returns a daily breakdown of QURL creation counts for the current
+        Returns a daily breakdown of qURL creation counts for the current
         billing period. Intended for dashboard chart rendering.
         Requires JWT authentication (dashboard endpoint).
       operationId: getUsageDaily
@@ -1155,9 +1725,21 @@ paths:
         Creates a Stripe Checkout session for plan upgrade.
         Returns a URL to redirect the user to Stripe's hosted checkout page.
         Requires JWT authentication (dashboard endpoint). API key authentication is not supported.
+
+        The `plan` field selects which paid plan to check out into.
+        Only purchasable plans are permitted (currently: `growth`); any
+        other value is rejected with 400.
       operationId: createBillingCheckout
       security:
         - bearerAuth: [qurl:write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBillingCheckoutRequest'
+            example:
+              plan: "growth"
       responses:
         '200':
           description: Checkout session created
@@ -1423,6 +2005,51 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '422':
+          description: Verification token has expired — use POST /v1/domains/{domain}/regenerate-token to get a new one
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/domains/{domain}/regenerate-token:
+    post:
+      tags:
+        - Domains
+      summary: Regenerate verification token
+      description: |
+        Regenerates the DNS verification token for a custom domain. The previous
+        token is invalidated immediately. A new TXT record must be configured
+        with the returned token before calling the verify endpoint.
+
+        Only allowed for domains in `pending_verification` or `failed` status.
+        The new token expires after 7 days.
+      operationId: regenerateToken
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/DomainName'
+      responses:
+        '200':
+          description: Token regenerated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomainResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Token regeneration not allowed for current domain status
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
         '429':
           $ref: '#/components/responses/RateLimitExceeded'
         '500':
@@ -1461,6 +2088,7 @@ paths:
               example:
                 data:
                   - webhook_id: "wh_abc123def456ghij"
+                    owner_id: "auth0|user123"
                     url: "https://example.com/webhooks/qurl"
                     events: ["qurl.created", "qurl.accessed"]
                     status: "active"
@@ -1502,7 +2130,7 @@ paths:
             example:
               url: "https://example.com/webhooks/qurl"
               events: ["qurl.created", "qurl.accessed", "qurl.revoked"]
-              description: "Production webhook for QURL events"
+              description: "Production webhook for qURL events"
       responses:
         '201':
           description: Webhook created successfully
@@ -1520,11 +2148,12 @@ paths:
               example:
                 data:
                   webhook_id: "wh_abc123def456ghij"
+                  owner_id: "auth0|user123"
                   url: "https://example.com/webhooks/qurl"
-                  secret: "whsec_EXAMPLE000000000000000000..."
+                  secret: "whsec_K8xQp9H2sJ9Lx7R4AaBbCcDdEeFf..."
                   events: ["qurl.created", "qurl.accessed", "qurl.revoked"]
                   status: "active"
-                  description: "Production webhook for QURL events"
+                  description: "Production webhook for qURL events"
                   created_at: "2024-01-08T10:30:00Z"
                   updated_at: "2024-01-08T10:30:00Z"
                   failure_count: 0
@@ -1548,7 +2177,47 @@ paths:
               summary: Webhook event delivery
               description: |
                 Event payload delivered to your webhook URL.
-                Verify authenticity using the QURL-Signature header with HMAC-SHA256.
+
+                Header names MUST be treated as case-insensitive per RFC 9110 §5.1. Every delivery carries:
+
+                - `QURL-Signature` — HMAC-SHA256 of the raw request body, computed with your webhook secret. Verify on every request.
+                - `QURL-Event` — the event type (e.g., `qurl.created`).
+                - `QURL-Delivery` — a unique delivery ID for idempotent processing and log correlation.
+                - `User-Agent` — fixed `QURL-Webhook/1.0`. Receivers with UA-based allowlists may match on this value.
+              parameters:
+                - name: QURL-Signature
+                  in: header
+                  required: true
+                  description: HMAC-SHA256 of the raw request body, hex-encoded.
+                  schema:
+                    type: string
+                    example: 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90'
+                - name: QURL-Event
+                  in: header
+                  required: true
+                  description: Event type that triggered this delivery.
+                  schema:
+                    type: string
+                    example: 'qurl.created'
+                - name: QURL-Delivery
+                  in: header
+                  required: true
+                  description: Unique delivery ID for log correlation and idempotent processing.
+                  schema:
+                    type: string
+                    example: 'wd_abc123def456ghij'
+                # `required: true` here means the producer (qurl-service) commits
+                # to always sending this header, NOT that receivers must validate it.
+                # The description below explicitly tells receivers not to reject on
+                # UA mismatch.
+                - name: User-Agent
+                  in: header
+                  required: true
+                  description: |
+                    Fixed identifier for outbound qURL webhook deliveries. We always send this value, so receivers MAY use it for UA-based allowlisting or log filtering — but receivers SHOULD NOT reject deliveries solely on a User-Agent mismatch (future minor versions may bump the suffix; match-on-prefix `QURL-Webhook/` is recommended).
+                  schema:
+                    type: string
+                    enum: ['QURL-Webhook/1.0']
               requestBody:
                 required: true
                 content:
@@ -1579,13 +2248,13 @@ paths:
                 data:
                   - type: "qurl.created"
                     category: "resource"
-                    description: "A new QURL was created"
+                    description: "A new qURL was created"
                   - type: "qurl.accessed"
                     category: "access"
-                    description: "A QURL was successfully accessed"
+                    description: "A qURL was successfully accessed"
                   - type: "qurl.access_denied"
                     category: "access"
-                    description: "Access to a QURL was denied by policy"
+                    description: "Access to a qURL was denied by policy"
                   - type: "quota.exceeded"
                     category: "quota"
                     description: "Quota limit reached, action blocked"
@@ -1783,6 +2452,8 @@ paths:
       operationId: createApiKey
       security:
         - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/APIKeyMintIdempotencyKey'
       requestBody:
         required: true
         content:
@@ -1794,7 +2465,7 @@ paths:
               scopes: ["qurl:read", "qurl:write"]
       responses:
         '201':
-          description: API key created successfully
+          description: API key created successfully.
           headers:
             Location:
               description: URL of the created API key resource
@@ -1809,8 +2480,8 @@ paths:
               example:
                 data:
                   key_id: "key_abc123def456"
-                  api_key: "lv_test_EXAMPLE00000000000000000000"
-                  key_prefix: "lv_test_EXAM"
+                  api_key: "lv_live_a3x9Kp2mN8qR5sT7wY0zBcDfGhJkLmNp"
+                  key_prefix: "lv_live_a3x9"
                   name: "Production integration"
                   scopes: ["qurl:read", "qurl:write"]
                   status: "active"
@@ -1830,10 +2501,33 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: |
+            The supplied `Idempotency-Key` was previously used with a
+            different request body. Send the original body or use a
+            fresh key.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
         '429':
           $ref: '#/components/responses/RateLimitExceeded'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '503':
+          description: |
+            Transient failure while processing the idempotent request.
+            Retry the same request with the same `Idempotency-Key`.
+          headers:
+            Retry-After:
+              description: Advisory delay before retrying (seconds).
+              schema:
+                type: integer
+                example: 1
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
     get:
       tags:
         - API Keys
@@ -1876,7 +2570,7 @@ paths:
               example:
                 data:
                   - key_id: "key_abc123def456"
-                    key_prefix: "lv_test_EXAM"
+                    key_prefix: "lv_live_a3x9"
                     name: "Production integration"
                     scopes: ["qurl:read", "qurl:write"]
                     status: "active"
@@ -1936,7 +2630,7 @@ paths:
               example:
                 data:
                   key_id: "key_abc123def456"
-                  key_prefix: "lv_test_EXAM"
+                  key_prefix: "lv_live_a3x9"
                   name: "Updated key name"
                   scopes: ["qurl:read"]
                   status: "active"
@@ -2040,7 +2734,7 @@ paths:
         - Access Codes
       summary: Create an access code
       description: |
-        Creates a new access code for a QURL resource. The plaintext code is returned only
+        Creates a new access code for a qURL resource. The plaintext code is returned only
         once in the response - store it securely.
 
         Requires system-tier account. The resource must exist and be owned by the authenticated user.
@@ -2184,19 +2878,23 @@ components:
           authorizationUrl: https://auth.layerv.ai/authorize
           tokenUrl: https://auth.layerv.ai/oauth/token
           scopes:
-            qurl:read: Read access to QURLs and quota
-            qurl:write: Create, update, and delete QURLs
-            qurl:resolve: Resolve access tokens and trigger firewall access
+            qurl:read: Read access to qURLs and quota
+            qurl:write: Create, update, and delete qURLs
+            qurl:resolve: Resolve access tokens and grant network access
+            qurl:agent: Bootstrap LayerV qURL Connector agents (POST /v1/agent/bootstrap)
 
   parameters:
     QurlId:
       name: id
       in: path
       required: true
-      description: QURL resource ID
+      description: |
+        Resource ID (r_ prefix) or qURL display ID (q_ prefix). Both are accepted.
+        The r_ ID identifies the protected URL; the q_ ID identifies a specific access token.
+        If a q_ ID is passed, the API resolves it to its parent resource automatically.
       schema:
         type: string
-        pattern: '^r_[a-z0-9_-]{11}$'
+        pattern: '^(r_[a-z0-9_-]{11}|q_[0-9a-f]{11})$'
         example: "r_k8xqp9h2sj9"
 
     WebhookId:
@@ -2230,17 +2928,56 @@ components:
         maxLength: 256
         example: "req_abc123_create_dashboard"
 
+    APIKeyMintIdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: |
+        Caller-supplied opaque token (32-256 characters). Identical
+        retries with the same key and body return the original
+        response. A different body under the same key returns 409.
+        A UUIDv4 or UUIDv7 is the simplest valid value. The 32-char
+        minimum is stricter than the generic `Idempotency-Key`
+        parameter to ensure adequate entropy on this security-
+        sensitive endpoint.
+      schema:
+        type: string
+        minLength: 32
+        maxLength: 256
+        example: "0192f7c4-3b8a-7e2f-9d01-4cf8a1b6e3d2"
+
   schemas:
     CreateQurlRequest:
       type: object
-      required:
-        - target_url
       properties:
+        # `type` is a plain `type: string` (no inline enum, no $ref to
+        # ResourceType) so the OpenAPI middleware doesn't reject unknown
+        # values before reaching the handler. The handler runs the
+        # narrower runtime check and rejects without echoing the offered
+        # value (PublicResourceTypeAllowedSuffix — `must be "url"`).
+        # Pushing the rejection to middleware-level enum validation
+        # would leak the full ResourceType set through the middleware's
+        # default error shape — see TestResourceTypeEnumParity for the
+        # tripwire.
+        #
+        # "Accepted on input" and "named in the rejection message" are
+        # deliberately decoupled: this surface accepts more values than
+        # the message advertises. The message is the customer-facing
+        # contract; the accepted-input set widens for internal use
+        # (connectors mint transit qURLs here) without re-publishing
+        # that nomenclature.
+        type:
+          type: string
+          default: url
+          description: Resource type for the resource the qURL backs. Defaults to `url`; other values may be available to specific integrations. See the `ResourceType` schema for the full runtime enum.
+          example: "url"
         target_url:
           type: string
           format: uri
           maxLength: 2048
-          description: The URL to protect with QURL (max 2048 characters)
+          description: |
+            The URL to protect with qURL (max 2048 characters). Required for
+            standard reverse-proxy qURLs.
           example: "https://internal.example.com/dashboard"
         expires_in:
           type: string
@@ -2250,28 +2987,81 @@ components:
           example: "7d"
         one_time_use:
           type: boolean
-          description: Whether this QURL expires after a single use
+          description: Whether this qURL expires after a single use
           default: false
         max_sessions:
           type: integer
           minimum: 0
           maximum: 1000
           description: |
-            Maximum concurrent sessions allowed.
-            0 = unlimited (default), 1-1000 = hard limit.
+            Maximum concurrent sessions for this qURL token.
+            0 = unlimited (default), 1-1000 = hard per-token limit.
+            The cap is per minted qURL, not resource-wide: multiple active
+            qURLs for the same resource can each admit up to this limit.
+            Note: `0` (unlimited) relies on `one_time_use: false`. If
+            `one_time_use` is omitted, some resource types default to a
+            single-visitor link, which makes `0` resolve to one visitor — set
+            `one_time_use: false` explicitly to guarantee unlimited concurrent
+            visitors. Resource types that already default to multi-visitor
+            links are unaffected.
+            Sessions are currently counted per source IP, so visitors sharing
+            a NAT/egress IP count as one session and are evaluated against
+            access_policy as that single IP.
         session_duration:
           type: string
           description: |
-            How long access lasts after someone clicks this QURL.
-            Controls the session/cookie lifetime, separate from the QURL link expiration (expires_in).
-            Supports: minutes (5m), hours (1h), days (1d). Minimum: 5 minutes. Maximum: 24 hours.
+            How long access lasts after someone successfully reaches the content.
+            Controls the session/cookie lifetime, separate from the qURL link expiration (expires_in).
+            The timer starts when the page loads, not when the link is clicked — on slow networks, page load can take several seconds before the timer begins. For a recipient on a slow connection, total time-to-expiry from the moment the link is clicked can be up to twice the configured session_duration in the worst case (for example, a 5-minute session_duration can stay accessible for up to 10 minutes total wall-clock time if the page takes its full pre-arrival window to load).
+            Supports: seconds (30s), minutes (5m), hours (1h), days (1d). Minimum: 1 second. Maximum: 24 hours.
             Default: server default (typically 1 hour).
+
+            The value on the FIRST create for a given `target_url`
+            establishes the resource-level cap (surfaced as
+            `ResourceData.session_duration_cap`). Subsequent creates that
+            dedup to the same resource, `mint_link` calls, and PATCH
+            updates all reject `session_duration` values exceeding that
+            cap with HTTP 400 `invalid_session_duration`. To use a
+            different cap, create a resource with a different `target_url`.
+
+            **Timing precision.** Two distinct effects can make the
+            effective access window differ from the configured value:
+            a front-edge effect (the page-load offset described in
+            the opening paragraph of this description — the timer
+            starts at page load, not link click) and a back-edge
+            effect (the connection-tail described below).
+            Access denial is exact at the timer: every new request
+            after `session_duration` from page load is rejected
+            immediately. An already-established connection may
+            continue to receive data for a short window past the
+            timer:
+
+            - **Typical request/response flows:** tail closes within
+              a few seconds to about a minute.
+            - **Long-lived streaming connections:** Server-Sent
+              Events, WebSockets, and in-progress large downloads
+              may continue until the underlying TCP connection
+              naturally closes via idle timeout, server reset, or
+              client disconnect.
+            - **`session_duration` longer than about a minute:** the
+              tail is generally not observable; access denial at the
+              timer and the underlying network-level close converge
+              there.
+
+            Treat `session_duration` as a strong cap on *new* access
+            (denied exactly at the configured value) rather than as
+            a guaranteed instant cutoff for connections that were
+            already in flight when the timer fired. If you set a
+            short `session_duration`, both effects apply: the
+            page-load offset on the front edge can extend total
+            wall-clock access, and the connection-tail on the back
+            edge can extend per-connection access past the timer.
           example: "1h"
         access_policy:
           $ref: '#/components/schemas/AccessPolicy'
         label:
           type: string
-          description: Human-readable label identifying who this QURL is for
+          description: Human-readable label identifying who this qURL is for
           maxLength: 500
           example: "Alice from Acme"
         custom_domain:
@@ -2284,16 +3074,183 @@ components:
             if a resource already exists for this target URL.
           example: "app.example.com"
 
+    CreateQurlForResourceRequest:
+      type: object
+      description: |
+        Request body for `POST /v1/resources/{id}/qurls`. The target
+        resource is identified by the URL path.
+
+        All fields are optional. An empty body mints a qURL with the
+        owner's plan defaults.
+      properties:
+        expires_in:
+          type: string
+          description: |
+            Duration until expiration. Supports: hours (24h), days (7d), weeks (1w).
+            Minimum: 1 minute. Maximum varies by plan: free=3 days, growth/enterprise=30 days. Default: 24h.
+          example: "7d"
+        one_time_use:
+          type: boolean
+          default: false
+          description: Whether this qURL expires after a single use.
+        max_sessions:
+          type: integer
+          minimum: 0
+          maximum: 1000
+          description: |
+            Maximum concurrent sessions for this qURL token.
+            0 = unlimited (default), 1-1000 = hard per-token limit.
+            The cap is per minted qURL, not resource-wide: multiple active
+            qURLs for the same resource can each admit up to this limit.
+            Note: `0` (unlimited) relies on `one_time_use: false`. If
+            `one_time_use` is omitted, some resource types default to a
+            single-visitor link, which makes `0` resolve to one visitor — set
+            `one_time_use: false` explicitly to guarantee unlimited concurrent
+            visitors. Resource types that already default to multi-visitor
+            links are unaffected.
+            Sessions are currently counted per source IP, so visitors sharing
+            a NAT/egress IP count as one session and are evaluated against
+            access_policy as that single IP.
+        session_duration:
+          type: string
+          description: |
+            How long access lasts after someone clicks this qURL.
+            Controls the session/cookie lifetime, separate from the qURL link expiration (expires_in).
+            Supports: seconds (30s), minutes (5m), hours (1h), days (1d). Minimum: 1 second. Maximum: 24 hours.
+            Default: server default (typically 1 hour).
+
+            New access is denied exactly at `session_duration`; an
+            already-established connection may continue receiving
+            data for a short window past that point on very short
+            values (longer for SSE / WebSocket streams — see the
+            canonical block). See `CreateQurlRequest.session_duration`
+            → **Timing precision** for the full semantics.
+          example: "1h"
+        access_policy:
+          $ref: '#/components/schemas/AccessPolicy'
+        label:
+          type: string
+          maxLength: 500
+          description: Human-readable label identifying who this qURL is for.
+          example: "Alice from Acme"
+
+    # Enum-value definitions only. The read-side redaction documentation
+    # for transit rows lives on `ResourceData.type` (the read-response
+    # property), not here — so SDK consumers reading the write-side
+    # `CreateResourceRequest.type` autocompletion (which $ref's this
+    # schema) don't see read-side strip semantics that don't apply on
+    # the write path.
+    ResourceType:
+      type: string
+      enum: [url, tunnel, transit]
+      x-enum-varnames: [ResourceTypeUrl, ResourceTypeTunnel, ResourceTypeTransit]
+      default: url
+      description: |
+        Resource type. `url` is a target-URL proxy (default). `tunnel`
+        is a qURL Connector resource for LayerV-provisioned callers.
+        `transit` is connector-owned (user-uploaded content
+        via integrations). See `ResourceData.type` for the read-side
+        redaction contract that applies on management-API read
+        responses for non-`url` rows.
+
+    # `knock_resource_id` is consumed by LayerV-managed reverse-connection
+    # clients to choose the public NHP resource they knock before opening their
+    # control connection. Internal upstream routing URLs (`upstream_addr`,
+    # `frps-*`, Cloud Map names, etc.) must stay out of public response schemas;
+    # the client learns the public FRP TCP target from the NHP ACK's
+    # ResourceHost entry after it knocks this logical NHP resource.
+    #
+    # The public docs posture is intentionally terse: no internal host examples,
+    # no URL format, and cross-repo naming details stay in source comments rather
+    # than generated Scalar output.
+    #
+    # Cross-repo contract: qurl-service returns placement-neutral
+    # `qurl-tunnel-server`. NHP owns AZ placement and returns the selected
+    # public FRP host:port in the ACK's ResourceHost entry under that same key.
+    # Clients must not derive placement from internal routing URLs.
+    #
+    # This property intentionally lives on ResourceData only. Bootstrap clients
+    # use GET/POST /v1/resources; qURL mint responses are shareable-link
+    # surfaces and must not grow tunnel-placement metadata.
+    #
+    # Keep this as a bare `type: string` component (no enum, pattern, or object)
+    # so oapi-codegen continues to emit a Go type alias. Call sites take string
+    # pointers directly; changing this into a defined string type is a generated
+    # API break even if the wire shape stays identical.
+    KnockResourceID:
+      type: string
+      readOnly: true
+      description: Internal use.
+
     CreateResourceRequest:
       type: object
-      required:
-        - target_url
+      description: |
+        Request body for `POST /v1/resources`.
+
+        The endpoint is idempotent on `(owner_id, target_url)` for URL
+        resources — a second call with the same target URL returns the
+        existing resource (200 semantics, served as 201 for shape
+        consistency). To preserve that contract, the `alias` field
+        behaves narrowly on POST:
+
+          - If no resource exists yet: creates a new resource carrying
+            the alias (subject to per-owner uniqueness).
+          - If a matching resource exists AND the request omits `alias`,
+            OR the request `alias` equals the existing binding:
+            returns the existing resource as-is. Idempotent.
+          - If a matching resource exists AND has no alias, but the
+            request supplies `alias`: returns 409
+            `resource_alias_mismatch`. The caller must use `PATCH
+            /v1/resources/{id}` to set an alias on an existing
+            resource — the alias is not claimed (so `alias_in_use`
+            would be wrong); the existing resource is the conflict.
+          - If a matching resource exists AND the request `alias`
+            disagrees with the existing binding: returns 409
+            `resource_alias_mismatch`. Silently rebinding on what
+            looks like an idempotent create is the failure mode the
+            upgrade-path 409 was designed to prevent; use PATCH to
+            rebind explicitly.
+
+        **Cross-type idempotency.** Dedup matches on
+        `(owner, target_url)`. If a row already exists for that
+        pair and your `type` disagrees with it, the server
+        returns `409 resource_type_conflict` — the redaction
+        posture differs by `type`, so silently inheriting an
+        existing row of the wrong type would invert the caller's
+        privacy expectations.
+
+        | Your request `type` | Existing row | Result |
+        |---|---|---|
+        | `url`     | none                | `201` — new url row |
+        | `url`     | `url` for same URL  | `201` — idempotent (existing url row) |
+        | `url`     | `transit` for same URL | **`409 resource_type_conflict`** |
+        | `transit` | none                | `201` — new transit row |
+        | `transit` | `transit` for same URL | `201` — idempotent (existing transit row) |
+        | `transit` | `url` for same URL  | **`409 resource_type_conflict`** |
+
+        `tunnel` resources don't participate in target-URL dedup,
+        so each tunnel create always yields a fresh resource.
+
+        **Remediation on `409 resource_type_conflict`:** the URL
+        is already registered for this owner under a different
+        resource type, and the redaction contract on the two
+        types is not interchangeable. Either reuse the existing
+        row (via `GET /v1/resources/{id}` if you know the ID,
+        or by accepting the existing flow) or revoke it via
+        `DELETE /v1/resources/{id}` and retry. The `error.detail`
+        field on the response identifies both types
+        (`existing is type=…, request is type=…`).
+
+        See `ResourceData.type` for the per-field redaction
+        contract on non-`url` rows.
       properties:
+        type:
+          $ref: '#/components/schemas/ResourceType'
         target_url:
           type: string
           format: uri
           maxLength: 2048
-          description: The URL to protect
+          description: The URL to protect.
         description:
           type: string
           maxLength: 500
@@ -2305,6 +3262,122 @@ components:
           maxItems: 10
         custom_domain:
           type: string
+          maxLength: 253
+          description: |
+            Optional custom domain to bind to this resource. Must be a
+            domain previously verified via the domains API.
+        alias:
+          type: string
+          minLength: 3
+          maxLength: 64
+          pattern: '^[a-z][a-z0-9-]{1,62}[a-z0-9]$'
+          description: |
+            Optional human-readable handle for the resource, unique per
+            owner. Format: 3–64 lowercase alphanumeric chars and
+            hyphens, must start with a letter and end alphanumeric.
+            Reserved words (e.g. `admin`, `qurl`, `tunnel`) are
+            rejected with 400 `alias_reserved`. Collisions with another
+            of your resources return 409 `alias_in_use`. Disagreeing
+            with the alias of an existing resource for the same
+            target URL returns 409 `resource_alias_mismatch`.
+          example: "dev-dashboard"
+        slug:
+          type: string
+          minLength: 3
+          maxLength: 64
+          pattern: '^[a-z][a-z0-9-]{1,62}[a-z0-9]$'
+          # Customer-facing description kept terse per
+          # docs/claude/api-codegen.md sparse-description guidance.
+          # Internal wire-error matrix for maintainers (Scalar
+          # strips YAML comments; repo is private; comment stays
+          # internal):
+          #
+          #   Auth        Serialization     Status  Code             Where
+          #   ─────────────────────────────────────────────────────────────────────────
+          #   owner       slug omitted      400     invalid_input    handler (slug-required)
+          #   owner       slug ""           400     validation_error openapi (minLength:3)
+          #   bootstrap   slug omitted      403     forbidden        handler (bound-slug)
+          #   bootstrap   slug ""           400     validation_error openapi (minLength:3, upstream of handler)
+          #   any         non-tunnel + slug 400     invalid_input    handler
+          #
+          # Bootstrap+empty is the subtle row: openapi runs AFTER
+          # auth in prod (router.go ~413/~428), so even bootstrap-
+          # authed requests get intercepted by minLength:3 before
+          # the bound-slug 403 fires. In-process bootstrap callers
+          # (Go unit tests, future HTTP-skipping APIs) reach the
+          # handler directly and DO see the 403; the matrix above
+          # documents the HTTP wire shape, not the in-process one.
+          # Both surfaces are fenced — HTTP by
+          # TestTunnelResourceSlugRequired_HTTPPipeline, in-process
+          # by TestResourceCreate_TunnelBootstrapRestriction_
+          # RejectsUnboundShapes/empty_slug.
+          description: |
+            Stable handle for tunnel-type resources, unique per owner
+            across that owner's tunnel resources. **Required when
+            `type=tunnel`**; forbidden on `url` or `transit`
+            resources (returns 400).
+
+            Owner-authenticated requests missing the required slug
+            return 400; restricted bootstrap-purpose API keys return
+            403 because the slug binding is part of the key's grant.
+            `error.code` is the stable contract; programmatic clients
+            should rely on it rather than the `detail` text, which
+            may be reworded between releases.
+
+            Distinct from `alias`: slugs are immutable post-create
+            (no PATCH path mutates them); aliases are mutable.
+            Use slug when the caller needs to look up the same
+            `resource_id` across retries or process restarts; use
+            alias when the caller needs to rename a display handle.
+
+            Format: 3–64 lowercase alphanumeric chars and hyphens,
+            must start with a letter and end alphanumeric. No
+            reserved-word set.
+
+            Without `find_or_create=true`, a `(owner, slug)` collision
+            returns 409 `slug_in_use`. With `find_or_create=true`,
+            the existing tunnel resource is returned (idempotent) —
+            unless that resource was revoked, in which case the call
+            returns 409 `resource_revoked`. See `find_or_create`
+            for the full dispatch matrix.
+          example: "prod-dashboard"
+        find_or_create:
+          type: boolean
+          description: |
+            Find-or-create mode for tunnel resources keyed on
+            `(owner, slug)`. Defaults to false (plain create
+            semantics — slug collisions return 409 `slug_in_use`).
+
+            When true:
+              - `type` must be `tunnel` (returns 400 otherwise)
+              - `slug` is required (returns 400 otherwise)
+              - If a tunnel resource exists for `(owner, slug)`:
+                - Active → returns 201 with the existing resource
+                  (idempotent — same `resource_id` across retries)
+                - Revoked → returns 409 `resource_revoked`. The
+                  caller must `DELETE /v1/resources/{id}` (or pick
+                  a different slug) before the slug becomes
+                  reclaimable. Revoked rows are never rolled over to
+                  a fresh identity; this protects callers that have
+                  distributed the old `resource_id` (qURL links,
+                  bookmarks, cached identifiers) from receiving a
+                  different identity on retry.
+              - If no resource exists → returns 201 with a freshly
+                created resource
+
+            On the found-existing branch, the request's `alias`,
+            `description`, and `tags` are NOT applied to the
+            returned resource — only the slug match drives the
+            lookup. To mutate alias/description/tags on an existing
+            resource, use `PATCH /v1/resources/{id}`.
+
+            Race semantics: two concurrent find-or-create calls for
+            the same `(owner, slug)` resolve to a single resource;
+            the loser may receive 409 `slug_in_use` on the first
+            call and should retry once, at which point the
+            find-existing path returns the winning row idempotently.
+          default: false
+          example: true
 
     UpdateResourceRequest:
       type: object
@@ -2320,6 +3393,7 @@ components:
           maxItems: 10
         custom_domain:
           type: string
+          maxLength: 253
         preserve_host:
           type: boolean
           description: |
@@ -2327,6 +3401,26 @@ components:
             via a custom domain. When true, the custom domain is sent as the Host header.
             When false (default), the target server's hostname is used.
             Only meaningful when custom_domain is set.
+        alias:
+          type: string
+          nullable: true
+          minLength: 3
+          maxLength: 64
+          pattern: '^[a-z][a-z0-9-]{1,62}[a-z0-9]$'
+          description: |
+            Set, rebind, or clear the resource's alias under RFC 7396
+            JSON Merge Patch semantics:
+
+              - omitted → no change.
+              - `null` → clear the alias and release the uniqueness
+                sentinel. Equivalent to deleting the alias.
+              - string value → set or rebind. Pattern, length, and
+                reserved-word rules match `CreateResourceRequest.alias`.
+
+            Sending an empty string (`""`) is rejected with `400
+            alias_invalid_format` to avoid the silent-no-op trap on
+            callers building this body from user input — use `null`
+            for the clear directive.
 
     ResourceData:
       type: object
@@ -2334,8 +3428,40 @@ components:
         resource_id:
           type: string
           pattern: '^r_[a-z0-9_-]{11}$'
+        # `type` is a plain `type: string` (no $ref to ResourceType)
+        # so the response schema doesn't pin the wire shape to the full
+        # ResourceType enum — that decoupling lets the response carry
+        # internal-only values (e.g. transit on connector reads, tunnel
+        # on internal callers) without OpenAPI middleware rejecting
+        # them at the response-validation boundary.
+        # TestResourceTypeEnumParity pins the contract.
+        #
+        # Runtime source of truth for the transit-row redaction list
+        # in the description below is internal/api/handlers/{resource,
+        # server}.go (toResourceData / toQurlData, under the
+        # shouldStripDashboardFields branch). If you add a field to the
+        # strip there, update the description's field list in the same
+        # PR. TestOpenAPISpec_ResourceDataTypeRedactionList fences the
+        # spec side; docs/claude/connector-redaction.md pins the
+        # operator-facing-docs side.
+        type:
+          type: string
+          description: |
+            Resource type (see `ResourceType` for the full enum).
+            Management-API read responses on connector-owned rows
+            redact user-content fields (`target_url`, `description`,
+            `tags`, `custom_domain`, `alias`, `preserve_host`,
+            `qurl_count`, `slug`) — list/detail responses include the
+            row but with those fields omitted.
         target_url:
           type: string
+          description: |
+            The URL to protect. Optional — omitted (field absent from
+            the JSON object, NOT serialized as null) when not applicable
+            to this resource, or when the resource is owned by a
+            connector.
+        knock_resource_id:
+          $ref: '#/components/schemas/KnockResourceID'
         status:
           type: string
           enum: [active, revoked]
@@ -2348,19 +3474,97 @@ components:
         custom_domain:
           type: string
           nullable: true
+        alias:
+          type: string
+          nullable: true
+          description: |
+            Per-owner human-readable handle for the resource (e.g.
+            `dev-dashboard`). `null` when no alias is set. Lookup via
+            `GET /v1/resources?alias={alias}` (returns a 0- or 1-item
+            list).
+        slug:
+          type: string
+          readOnly: true
+          description: |
+            Per-owner immutable identity supplied at create time.
+            Echo of the `slug` field on `POST /v1/resources`; omitted
+            on resources that were not created with a slug. Distinct
+            from `alias`: slugs are immutable post-create, aliases are
+            mutable. Lookup via `GET /v1/resources?slug={slug}` returns
+            a 0- or 1-item active-resource list. See
+            `CreateResourceRequest.slug` for format, uniqueness, and
+            `find_or_create` semantics.
         preserve_host:
           type: boolean
           description: Whether to preserve the original Host header when proxying via custom domain
           default: false
+        session_duration_cap:
+          type: integer
+          description: |
+            Resource-level upper bound (in seconds) on per-qURL
+            `session_duration`. Anchored at create time from the first
+            `POST /v1/qurls` that established this resource and frozen
+            thereafter — subsequent `mint_link`, `POST /v1/qurls` against
+            the same `target_url` (which dedups to this resource), and
+            `PATCH /v1/resources/{id}/qurls/{qurl_id}` calls reject
+            `session_duration` values exceeding this cap with HTTP 400
+            `invalid_session_duration`. Requests that omit
+            `session_duration` inherit this value so the uploader's
+            intent is preserved across follow-up mints.
+
+            Omitted on resources that were created without a
+            `session_duration` (no per-resource cap; the 1s–24h absolute
+            bounds still apply). Resources created via `POST /v1/resources`
+            (without an initial qURL minted in the same call) currently
+            carry no cap regardless of any subsequent `mint_link` value
+            — only the `POST /v1/qurls` create path anchors the cap. To
+            change the cap, either create a new resource with a different
+            `target_url`, or revoke the existing resource and recreate it
+            at the same `target_url` with the desired `session_duration`
+            — the dedup index only matches active rows, so a revoked
+            resource is not reused and the new create anchors a fresh cap.
+          minimum: 1
+          maximum: 86400
+          example: 30
         qurl_count:
           type: integer
-          description: Number of active QURLs for this resource
+          description: |
+            Number of qURL token rows for this resource. Rows revoked or expired
+            but still awaiting background TTL cleanup can remain counted until
+            cleanup completes. Omitted when qURL count lookup is unavailable or
+            qURL fields are suppressed; treat an omitted value as unknown rather
+            than zero.
         created_at:
           type: string
           format: date-time
         expires_at:
           type: string
           format: date-time
+        # Redaction note: tombstoned_at is intentionally surfaced
+        # on connector-owned rows too. The field is a server-internal
+        # lifecycle timestamp with zero viewer identity, so it is
+        # NOT in the redaction strip set — see the connector-redaction
+        # internal docs for the threat-model reasoning.
+        #
+        # Implementation note (intentionally not in the public
+        # description): the dashboard `GET /v1/resources` list
+        # excludes connector-owned rows, so the field's current
+        # 200-response surface is alias lookup. As scanner
+        # coverage extends to other resource types, the surface
+        # broadens automatically.
+        tombstoned_at:
+          type: string
+          format: date-time
+          description: |
+            When the resource's lifecycle closed. Present only on
+            tombstoned resources; absent on active ones.
+            Consumers fetching a single resource by ID handle the
+            tombstoned-row case via the 410 response on
+            `GET /v1/resources/{id}` — the same timestamp surfaces
+            in `meta.tombstone.tombstoned_at`. List / alias-lookup
+            (`GET /v1/resources?alias=...`) responses include this
+            field on the row itself so callers can distinguish
+            tombstoned from active without a per-row probe.
 
     ResourceDetailData:
       type: object
@@ -2369,6 +3573,21 @@ components:
           $ref: '#/components/schemas/ResourceData'
         qurls:
           type: array
+          maxItems: 100
+          readOnly: true
+          description: |
+            Unordered bounded preview of per-qURL summaries for this resource
+            (maximum 100). This preview does not imply newest-first or any
+            stable ordering and is not active-first; an active qURL can be
+            absent from the preview when earlier token rows fill the cap.
+            When present, `resource.qurl_count` is the exact total; if omitted,
+            callers must treat truncation as unknown. There is currently
+            no paginated endpoint for the complete per-resource qURL summary
+            list; callers that need the full list should use `qurl_count` to
+            detect truncation and track the paginated-list follow-up. For
+            large resources, the preview and count are separate reads, so
+            concurrent qURL changes can make the preview length and
+            `resource.qurl_count` briefly differ.
           items:
             $ref: '#/components/schemas/QurlSummary'
 
@@ -2406,7 +3625,7 @@ components:
       type: object
       minProperties: 1
       description: |
-        Update a specific QURL token. Can extend expiration, update label,
+        Update a specific qURL token. Can extend expiration, update label,
         access policy, or max_sessions. At least one field must be provided.
         For expiry: provide exactly one of extend_by (relative) or expires_at (absolute).
       properties:
@@ -2427,18 +3646,34 @@ components:
         label:
           type: string
           maxLength: 500
-          description: Human-readable label for this QURL.
+          description: Human-readable label for this qURL.
         access_policy:
           $ref: '#/components/schemas/AccessPolicy'
         max_sessions:
           type: integer
           minimum: 0
           maximum: 1000
-          description: Maximum concurrent sessions (0 = unlimited).
+          description: Maximum concurrent sessions for this qURL token (0 = unlimited).
         session_duration:
           type: string
           description: |
-            How long access lasts after clicking. Minimum: 5 minutes. Maximum: 24 hours.
+            How long access lasts after clicking. Minimum: 1 second.
+            Maximum: 24 hours.
+
+            If the parent resource was created with a `session_duration`
+            (see `ResourceData.session_duration_cap`), values exceeding
+            that cap are rejected with HTTP 400 `invalid_session_duration`.
+            On a capped resource, sending an empty string for this field
+            applies the cap rather than the server default — the
+            uploader's intent supersedes the global default whenever a
+            cap is in force.
+
+            New access is denied exactly at `session_duration`; an
+            already-established connection may continue receiving
+            data for a short window past that point on very short
+            values (longer for SSE / WebSocket streams — see the
+            canonical block). See `CreateQurlRequest.session_duration`
+            → **Timing precision** for the full semantics.
           example: "1h"
 
     QurlSummaryResponse:
@@ -2457,7 +3692,7 @@ components:
           description: Unique session identifier
         qurl_id:
           type: string
-          description: QURL display ID (q_ prefix) that created this session
+          description: qURL display ID (q_ prefix) that created this session
         src_ip:
           type: string
           description: Client IP that created the session
@@ -2519,10 +3754,117 @@ components:
         meta:
           $ref: '#/components/schemas/ListMeta'
 
+    ConnectorInstallationStats:
+      type: object
+      required:
+        - resources
+        - qurls
+        - accesses_24h
+        - accesses_7d
+        - errors_24h
+      properties:
+        resources:
+          type: integer
+          format: int64
+          description: Number of protected resources associated with this installation.
+        qurls:
+          type: integer
+          format: int64
+          description: Number of active qURLs associated with this installation.
+        accesses_24h:
+          type: integer
+          format: int64
+          description: Successful accesses in the last 24 hours.
+        accesses_7d:
+          type: integer
+          format: int64
+          description: Successful accesses in the last 7 days.
+        errors_24h:
+          type: integer
+          format: int64
+          description: Failed connector actions in the last 24 hours.
+
+    ConnectorInstallationCapabilities:
+      type: object
+      required:
+        - configure
+        - disconnect
+        - reauth
+        - view_activity
+      properties:
+        configure:
+          type: boolean
+        disconnect:
+          type: boolean
+        reauth:
+          type: boolean
+        view_activity:
+          type: boolean
+
+    ConnectorInstallationSummary:
+      type: object
+      required:
+        - installation_id
+        - plugin_id
+        - label
+        - subject_kind
+        - subject_display_name
+        - status
+        - installed_at
+        - stats
+        - capabilities
+      properties:
+        installation_id:
+          type: string
+          description: Stable identifier for this connector installation.
+        plugin_id:
+          type: string
+          description: Connector plugin identifier.
+          example: slack
+        label:
+          type: string
+          description: Human-readable label for this installation.
+          example: Engineering Slack
+        subject_kind:
+          type: string
+          description: Connector-owned subject type.
+          example: slack_workspace
+        subject_display_name:
+          type: string
+          description: Display name for the connected workspace, guild, bucket, or account.
+          example: LayerV Engineering
+        status:
+          type: string
+          enum: [active, degraded, disconnected, needs_reauth]
+        installed_at:
+          type: string
+          format: date-time
+        last_activity_at:
+          type: string
+          format: date-time
+          nullable: true
+        stats:
+          $ref: '#/components/schemas/ConnectorInstallationStats'
+        capabilities:
+          $ref: '#/components/schemas/ConnectorInstallationCapabilities'
+
+    ConnectorInstallationListResponse:
+      type: object
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectorInstallationSummary'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+
     UpdateQurlRequest:
       type: object
       description: |
-        Update a QURL resource. Can extend expiration (via extend_by or expires_at)
+        Update a qURL resource. Can extend expiration (via extend_by or expires_at)
         and/or update tags and description. At least one field must be provided.
       properties:
         extend_by:
@@ -2576,30 +3918,44 @@ components:
             Mutually exclusive with expires_in.
         label:
           type: string
-          description: Human-readable label identifying who this QURL is for
+          description: Human-readable label identifying who this qURL is for
           maxLength: 500
           example: "Alice from Acme"
         one_time_use:
           type: boolean
-          description: Whether this QURL can only be used once
+          description: Whether this qURL can only be used once
           default: false
         max_sessions:
           type: integer
-          description: Maximum concurrent sessions (0 = unlimited)
+          description: Maximum concurrent sessions for this qURL token (0 = unlimited)
           minimum: 0
           maximum: 1000
           default: 0
         session_duration:
           type: string
           description: |
-            How long access lasts after clicking. Minimum: 5 minutes. Maximum: 24 hours.
+            How long access lasts after clicking. Minimum: 1 second.
+            Maximum: 24 hours.
+
+            If the parent resource was created with a `session_duration`
+            (see `ResourceData.session_duration_cap`), values exceeding
+            that cap are rejected with HTTP 400 `invalid_session_duration`.
+            Omitting this field on a capped resource inherits the cap;
+            on an uncapped resource the token receives the server default.
+
+            New access is denied exactly at `session_duration`; an
+            already-established connection may continue receiving
+            data for a short window past that point on very short
+            values (longer for SSE / WebSocket streams — see the
+            canonical block). See `CreateQurlRequest.session_duration`
+            → **Timing precision** for the full semantics.
           example: "1h"
         access_policy:
           $ref: '#/components/schemas/AccessPolicy'
 
     AccessPolicy:
       type: object
-      description: Access control policy for the QURL
+      description: Access control policy for the qURL
       x-go-type: domain.AccessPolicy
       x-go-type-import:
         path: github.com/layervai/qurl-service/internal/domain
@@ -2724,9 +4080,10 @@ components:
     QurlData:
       type: object
       description: |
-        Resource-level data for a protected URL. Per-QURL fields (one_time_use,
-        max_sessions, access_policy) are available in QurlSummary objects returned
-        by the resource detail endpoint.
+        Resource container for a protected URL. The `qurls` array (present on
+        single-get responses) is an unordered bounded preview (maximum 100) of
+        per-qURL details including access policy and session limits. On list
+        responses, only `qurl_count` is populated.
       properties:
         resource_id:
           type: string
@@ -2736,7 +4093,10 @@ components:
         target_url:
           type: string
           format: uri
-          description: The protected backend URL
+          description: |
+            The protected backend URL. Optional — omitted (field absent
+            from the JSON object, NOT serialized as null) when the
+            resource is owned by a connector.
         status:
           type: string
           enum: [active, revoked]
@@ -2748,11 +4108,11 @@ components:
           type: string
           format: date-time
           readOnly: true
-          description: When the QURL was created
+          description: When the qURL was created
         expires_at:
           type: string
           format: date-time
-          description: When the QURL expires
+          description: When the qURL expires
         description:
           type: string
           description: Human-readable description
@@ -2766,25 +4126,63 @@ components:
           type: string
           format: uri
           readOnly: true
-          description: The QURL site URL for accessing this resource
+          description: The qURL site URL for accessing this resource
         custom_domain:
           type: string
           nullable: true
           readOnly: true
-          description: Custom domain associated with this QURL
+          description: Custom domain associated with this qURL
+        slug:
+          type: string
+          readOnly: true
+          description: |
+            Per-owner immutable identity supplied at create time.
+            Echo of the `slug` field on `POST /v1/resources`; omitted
+            on resources that were not created with a slug. See
+            `ResourceData.slug` for the full description — the field
+            carries identical semantics on both response schemas.
+        qurl_count:
+          type: integer
+          readOnly: true
+          description: |
+            Number of qURL token rows for this resource. Rows revoked or expired
+            but still awaiting background TTL cleanup can remain counted until
+            cleanup completes. Omitted when qURL count lookup is unavailable or
+            qURL fields are suppressed; treat an omitted value as unknown rather
+            than zero.
+        qurls:
+          type: array
+          maxItems: 100
+          readOnly: true
+          description: |
+            Unordered bounded preview of per-qURL details (maximum 100).
+            Best-effort on single-get and omitted on list, preview lookup failure,
+            or redacted resource types. This preview does not imply newest-first
+            or any stable ordering and is not active-first; an active qURL can
+            be absent from the preview when earlier token rows fill the cap.
+            When present, `qurl_count` is the exact total; if omitted, callers
+            must treat truncation as unknown. There is
+            currently no paginated endpoint for the complete per-resource qURL
+            summary list; callers that need the full list should use
+            `qurl_count` to detect truncation and track the paginated-list
+            follow-up. For large resources, the preview and count are separate
+            reads, so concurrent qURL changes can make the preview length and
+            `qurl_count` briefly differ.
+          items:
+            $ref: '#/components/schemas/QurlSummary'
 
     CreateQurlData:
       type: object
-      description: Response data for QURL creation
+      description: Response data for qURL creation
       properties:
         qurl_id:
           type: string
           pattern: '^q_[a-f0-9]{11}$'
           readOnly: true
           description: |
-            Unique QURL identifier (q_ + first 11 hex chars of token hash).
-            Used as NHP resource ID and qurl_site subdomain. Each QURL gets
-            its own firewall rules keyed by this ID.
+            Unique qURL identifier (q_ + first 11 hex chars of token hash).
+            Used as NHP resource ID and qurl_site subdomain. Each qURL gets
+            its own access rules keyed by this ID.
           example: "q_3a7f2c8e91b"
         resource_id:
           type: string
@@ -2796,11 +4194,27 @@ components:
           format: uri
           readOnly: true
           description: Ephemeral access link (shown once, cannot be recovered)
+        branded_domain:
+          type: string
+          readOnly: true
+          description: |
+            Customer's bare branded hostname for anchor-text display
+            alongside `qurl_link`. See `MintLinkData.branded_domain` for
+            the canonical description (rendering pattern,
+            `provisioning_tls` caveat, live-status gating). Populated
+            when the resource has a `custom_domain` whose status is
+            usable; omitted otherwise.
+
+            Note: requests replayed via `Idempotency-Key` return the cached
+            response, so `branded_domain` reflects the domain status at
+            the time of the original request — not the current status.
+            Consumers caching create responses should re-fetch via the
+            resource if they need a live usability signal.
         qurl_site:
           type: string
           format: uri
           readOnly: true
-          description: Per-QURL site URL (https://{qurl_id}.qurl.site)
+          description: Per-qURL site URL (https://{qurl_id}.qurl.site)
         expires_at:
           type: string
           format: date-time
@@ -2808,8 +4222,15 @@ components:
         label:
           type: string
           readOnly: true
-          description: Human-readable label for this QURL
-
+          description: Human-readable label for this qURL
+        # See CreateQurlRequest.type — plain `type: string` (no inline
+        # enum, no $ref) so response-validation doesn't reject internal
+        # values at the OpenAPI middleware boundary.
+        # TestResourceTypeEnumParity guards this surface.
+        type:
+          type: string
+          readOnly: true
+          description: Resource type — echoes the type from the create request.
     QurlResponse:
       type: object
       properties:
@@ -2833,7 +4254,7 @@ components:
       properties:
         access_token:
           type: string
-          description: QURL access token (e.g., "at_k8xqp9h2sj9lx7r4abcdef")
+          description: qURL access token (e.g., "at_k8xqp9h2sj9lx7r4abcdef")
           pattern: '^at_[a-z0-9_-]{22}$'
           example: "at_k8xqp9h2sj9lx7r4abcdef"
 
@@ -2857,18 +4278,22 @@ components:
           example: "https://api.example.com/data"
         resource_id:
           type: string
-          description: QURL resource identifier
+          description: qURL resource identifier
           example: "r_k8xqp9h2sj9"
         access_grant:
           $ref: '#/components/schemas/AccessGrant'
 
     AccessGrant:
       type: object
-      description: Details of the firewall access that was granted
+      description: Details of the network access that was granted
+      required:
+        - expires_in
+        - granted_at
+        - src_ip
       properties:
         expires_in:
           type: integer
-          description: Seconds until firewall access expires
+          description: Seconds until network access expires
           example: 305
         granted_at:
           type: string
@@ -2893,16 +4318,54 @@ components:
     MintLinkData:
       type: object
       properties:
+        qurl_id:
+          type: string
+          pattern: '^q_[a-f0-9]{11}$'
+          readOnly: true
+          example: "q_a1b2c3d4e5f"
+          description: |
+            The minted qURL's primary key (prefix `q_`). Same
+            identifier as `CreateQurlData.qurl_id`. Webhook subscribers
+            receive `qurl.accessed` events keyed on this ID, so callers
+            that want to correlate access events back to the
+            recipient/context they minted FOR must capture this value
+            at mint time.
         qurl_link:
           type: string
           format: uri
           readOnly: true
           description: Single-use access link
+        branded_domain:
+          type: string
+          readOnly: true
+          description: |
+            Customer's bare branded hostname (e.g. `customer.com`) for
+            anchor-text display alongside `qurl_link`. Render as
+            `<a href="{qurl_link}">{branded_domain}</a>` — the access
+            token lives in `qurl_link`'s fragment, not here, so the
+            href must stay `qurl_link`. Populated when the resource has
+            a `custom_domain` whose status is usable (`verified`,
+            `provisioning_tls`, or `active`) and is owned by the
+            requesting tenant; omitted when no custom domain is set,
+            when the assigned domain has transitioned to a non-usable
+            status, or when the requesting tenant doesn't own the live
+            domain row (defends against domain churn — e.g. a domain
+            deleted and re-registered by a different tenant). During
+            `provisioning_tls` the branded host may not yet be serving
+            HTTPS, so treat the value as a display string until the
+            domain reaches `active`.
         expires_at:
           type: string
           format: date-time
           readOnly: true
-
+        # See CreateQurlRequest.type — plain `type: string` (no inline
+        # enum, no $ref) so response-validation doesn't reject internal
+        # values at the OpenAPI middleware boundary.
+        # TestResourceTypeEnumParity guards this surface.
+        type:
+          type: string
+          readOnly: true
+          description: Resource type — echoes the type of the underlying resource.
     MintLinkResponse:
       type: object
       properties:
@@ -2920,7 +4383,7 @@ components:
           type: array
           minItems: 1
           maxItems: 100
-          description: Array of QURL creation requests (1-100 items)
+          description: Array of qURL creation requests (1-100 items)
           items:
             $ref: '#/components/schemas/CreateQurlRequest'
 
@@ -2933,7 +4396,7 @@ components:
             succeeded:
               type: integer
               readOnly: true
-              description: Number of successfully created QURLs
+              description: Number of successfully created qURLs
             failed:
               type: integer
               readOnly: true
@@ -2964,11 +4427,20 @@ components:
           format: uri
           readOnly: true
           description: Access link (if success)
+        branded_domain:
+          type: string
+          readOnly: true
+          description: |
+            Customer's bare branded hostname (if success). See
+            `MintLinkData.branded_domain` for the canonical description,
+            including the `<a href="{qurl_link}">{branded_domain}</a>`
+            rendering pattern, the `provisioning_tls` HTTPS-not-yet-live
+            caveat, and the live-status + tenant-ownership gating.
         qurl_site:
           type: string
           format: uri
           readOnly: true
-          description: QURL site URL (if success)
+          description: qURL site URL (if success)
         expires_at:
           type: string
           format: date-time
@@ -3011,13 +4483,13 @@ components:
               type: integer
             resolve_per_minute:
               type: integer
-              description: Rate limit for internal token resolution (used by access infrastructure)
+              description: Rate limit for token resolution requests
             max_active_qurls:
               type: integer
-              description: Maximum active QURLs allowed (-1 = unlimited)
+              description: Maximum active qURLs allowed (-1 = unlimited)
             max_tokens_per_qurl:
               type: integer
-              description: Maximum tokens per QURL (-1 = unlimited)
+              description: Maximum tokens per qURL (-1 = unlimited)
             max_expiry_seconds:
               type: integer
               description: Maximum expiry duration in seconds (free=259200/3d, growth=2592000/30d, enterprise=2592000/30d)
@@ -3027,10 +4499,10 @@ components:
           properties:
             qurls_created:
               type: integer
-              description: Total QURLs created this period
+              description: Total qURLs created this period
             active_qurls:
               type: integer
-              description: Currently active QURLs
+              description: Currently active qURLs
             active_qurls_percent:
               type: number
               format: float
@@ -3069,7 +4541,7 @@ components:
         description:
           type: string
           description: Human-readable breakdown
-          example: "150 QURLs x $0.10/QURL"
+          example: "150 qURLs x $0.10/qURL"
 
     UsageCurrentPeriodData:
       type: object
@@ -3094,10 +4566,10 @@ components:
           description: End of the current billing period (UTC)
         qurls_created:
           type: integer
-          description: Number of QURLs created in this period
+          description: Number of qURLs created in this period
         active_qurls:
           type: integer
-          description: Number of currently active (non-expired, non-revoked) QURLs
+          description: Number of currently active (non-expired, non-revoked) qURLs
         cost_estimate:
           $ref: '#/components/schemas/UsageCostEstimate'
 
@@ -3121,7 +4593,7 @@ components:
           description: Calendar date (YYYY-MM-DD)
         qurls_created:
           type: integer
-          description: QURLs created on this date
+          description: qURLs created on this date
 
     UsageDailyData:
       type: object
@@ -3160,6 +4632,7 @@ components:
     # API Key schemas
     CreateApiKeyRequest:
       type: object
+      additionalProperties: false
       required:
         - name
         - scopes
@@ -3173,8 +4646,31 @@ components:
           minItems: 1
           items:
             type: string
-            enum: [qurl:read, qurl:write, qurl:resolve]
+            enum: [qurl:read, qurl:write, qurl:resolve, qurl:agent]
           description: Permissions granted to this API key
+        expires_in:
+          type: string
+          pattern: '^[0-9]+[smhdw]$'
+          description: >-
+            Optional lifetime for restricted tunnel bootstrap keys.
+            Defaults to 24h for purpose=tunnel_bootstrap and cannot
+            exceed 24h. Invalid format or bounds return 400
+            `invalid_duration`; using it without
+            purpose=tunnel_bootstrap returns 400 `invalid_input`.
+        purpose:
+          type: string
+          enum: [tunnel_bootstrap]
+          description: >-
+            Optional constrained key purpose. API-key-authenticated
+            callers may only create purpose=tunnel_bootstrap keys.
+        tunnel_slug:
+          type: string
+          pattern: '^[a-z][a-z0-9-]{1,62}[a-z0-9]$'
+          description: >-
+            Required when purpose=tunnel_bootstrap. The resulting key
+            may only bootstrap or find-or-create this tunnel slug.
+            Missing or purpose-mismatched values return 400
+            `invalid_input`.
 
     UpdateApiKeyRequest:
       type: object
@@ -3188,7 +4684,7 @@ components:
           minItems: 1
           items:
             type: string
-            enum: [qurl:read, qurl:write, qurl:resolve]
+            enum: [qurl:read, qurl:write, qurl:resolve, qurl:agent]
           description: |
             Updated permissions for the API key.
             Omit this field to leave scopes unchanged.
@@ -3206,7 +4702,7 @@ components:
           readOnly: true
           description: >-
             First 12 characters of the key for identification.
-            Includes the environment prefix (e.g., "lv_test_EXAM").
+            Includes the environment prefix (e.g., "lv_live_a3x9").
         name:
           type: string
         scopes:
@@ -3235,6 +4731,22 @@ components:
           type: string
           format: date-time
           readOnly: true
+        expires_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: >-
+            Expiration timestamp for restricted or expiring keys.
+            Omitted for non-expiring keys.
+        purpose:
+          type: string
+          enum: [tunnel_bootstrap]
+          readOnly: true
+          description: Optional constrained key purpose.
+        tunnel_slug:
+          type: string
+          readOnly: true
+          description: Slug restriction for tunnel bootstrap keys.
 
     CreateApiKeyData:
       allOf:
@@ -3320,7 +4832,7 @@ components:
       properties:
         resource_id:
           type: string
-          description: ID of the QURL resource this code grants access to
+          description: ID of the qURL resource this code grants access to
           pattern: '^r_[a-z0-9_-]{11}$'
           example: "r_k8xqp9h2sj9"
         name:
@@ -3350,7 +4862,7 @@ components:
           example: "acd_k8xqp9h2sj9"
         resource_id:
           type: string
-          description: ID of the QURL resource this code grants access to
+          description: ID of the qURL resource this code grants access to
           example: "r_k8xqp9h2sj9"
         name:
           type: string
@@ -3420,6 +4932,7 @@ components:
         - qurl.expired
         - qurl.revoked
         - qurl.updated
+        - resource.closed
         - qurl.accessed
         - qurl.access_denied
         - qurl.token_exhausted
@@ -3432,12 +4945,13 @@ components:
         - domain.deleted
       description: |
         Webhook event types:
-        - **qurl.created** - A new QURL was created
-        - **qurl.expired** - A QURL has expired
-        - **qurl.revoked** - A QURL was manually revoked
-        - **qurl.updated** - A QURL was updated (expiration, tags, or description)
-        - **qurl.accessed** - A QURL was successfully accessed
-        - **qurl.access_denied** - Access to a QURL was denied by policy
+        - **qurl.created** - A new qURL was created
+        - **qurl.expired** - A qURL's expiration time was reached. Fires once per qURL when its TTL elapses, regardless of prior state — a previously-revoked or already-consumed qURL that hits its TTL will still emit `qurl.expired`. Treat as a TTL-reached signal; consult current state if exclusivity with `qurl.revoked` or `qurl.token_exhausted` matters for your handler. **At-most-once per qURL lifetime:** fires at most once per qURL, ever. Extending a qURL whose `qurl.expired` already fired (via `PATCH /v1/qurls/{id}`) does NOT cause it to fire again when the new TTL elapses. Delivery begins in a future release.
+        - **qurl.revoked** - A qURL was manually revoked
+        - **qurl.updated** - A qURL was updated (expiration, tags, or description)
+        - **resource.closed** - All qURLs for the resource have terminated (expired, revoked, or exhausted) and no active sessions remain. Subscribers can use this as a release signal for per-resource side state (e.g., upstream-owned file storage). Delivery begins in a future release.
+        - **qurl.accessed** - A qURL was successfully accessed. For connector-owned resources (`type=transit`), viewer-identifying fields (`src_ip`, `user_agent`) are omitted from the payload. See `WebhookPayload` description for the full per-event redaction rules.
+        - **qurl.access_denied** - Access to a qURL was denied by policy
         - **qurl.token_exhausted** - A one-time-use token was fully consumed
         - **quota.warning** - Approaching quota limit (80%)
         - **quota.exceeded** - Quota limit reached, action blocked
@@ -3496,6 +5010,14 @@ components:
           type: string
           pattern: '^wh_[A-Za-z0-9_-]{16}$'
           readOnly: true
+        owner_id:
+          type: string
+          readOnly: true
+          description: |
+            Identifier of the account that owns this subscription.
+            Bound at create time from the authenticating API key and
+            immutable thereafter.
+          example: "auth0|user123"
         url:
           type: string
           format: uri
@@ -3541,7 +5063,7 @@ components:
               description: |
                 HMAC signing secret (only returned on create or regenerate).
                 Use this to verify the QURL-Signature header on incoming webhooks.
-              example: "whsec_EXAMPLE000000000000000000..."
+              example: "whsec_K8xQp9H2sJ9Lx7R4AaBbCcDdEeFf..."
 
     WebhookResponse:
       type: object
@@ -3646,6 +5168,46 @@ components:
       description: |
         Webhook event payload sent to your endpoint.
         Verify authenticity using the QURL-Signature header.
+
+        ## Connector-resource payload redaction
+
+        For resources created via a consumer connector (e.g., the
+        qURL Discord bot, the qURL S3 connector — modeled as
+        resources with `type=transit`), some events are suppressed
+        entirely and others are delivered with viewer-identifying
+        fields omitted from `data`.
+
+        The boundary exists because for connector-owned resources
+        the **account owner** (the person who installed the connector
+        and holds the API key) is NOT the same person as the **viewer**
+        (a Discord guild member, a Slack workspace user, etc. who
+        clicked the link). Forwarding viewer IP / User-Agent /
+        filename / target URL to the owner's webhook would let them
+        de-anonymize their members' activity.
+
+        ### `qurl.accessed` on connector resources
+
+        Delivered, but with `src_ip` and `user_agent` OMITTED from
+        `data`. The remaining fields (`qurl_id`, `resource_id`,
+        `access_count`, `consumed`) are safe — the account owner
+        already sees these via `GET /v1/qurls/{id}`.
+
+        ### Other events on connector resources
+
+        `qurl.created`, `qurl.updated`, `qurl.revoked`, `token.minted`
+        are suppressed entirely for connector resources — their
+        payloads include `target_url` and `description` (which the
+        connector populates with the original filename) and that
+        combination would leak the file metadata via the webhook
+        even though the dashboard strip hides it.
+
+        All other events default to suppression for connector
+        resources. Today this includes `resource.closed`, which is
+        currently not delivered to connector subscribers; a future
+        release will document its delivery semantics. Subscribers
+        to connector webhooks should not assume delivery of any
+        event other than `qurl.accessed` unless this section says
+        otherwise.
       properties:
         id:
           type: string
@@ -3664,7 +5226,57 @@ components:
         data:
           type: object
           additionalProperties: true
-          description: Event-specific data
+          description: |
+            Event-specific data. Field set varies by event type AND
+            by resource type. See the schema description for the
+            connector-resource redaction rules and per-event
+            field listings below.
+
+            ### `qurl.accessed` data fields
+
+            Always present:
+            - `qurl_id` (string) — qURL primary key
+            - `resource_id` (string) — resource primary key
+            - `access_count` (integer) — projected access count after this
+              access. For multi-use qURLs under concurrent load the
+              value is best-effort: two near-simultaneous accesses may
+              both observe the same `access_count`. Subscribers that
+              need an exact total should reconcile from
+              `GET /v1/qurls/{id}`.
+            - `consumed` (boolean) — whether the access consumed a one-time-use token
+
+            Present only for `type=url` and `type=tunnel` resources
+            (OMITTED for `type=transit` — connector-resource
+            redaction):
+            - `src_ip` (string) — client IP that accessed the qURL
+            - `user_agent` (string) — viewer's User-Agent header
+
+            #### `data` shape examples
+
+            URL / tunnel resource (full payload):
+
+            ```json
+            {
+              "qurl_id": "q_xyz789abcdef",
+              "resource_id": "r_k8xqp9h2sj9",
+              "access_count": 3,
+              "consumed": false,
+              "src_ip": "192.168.1.100",
+              "user_agent": "Mozilla/5.0..."
+            }
+            ```
+
+            Transit (connector-owned) resource — `src_ip` and
+            `user_agent` omitted:
+
+            ```json
+            {
+              "qurl_id": "q_abc456def789",
+              "resource_id": "r_p3wv8z9q4t2",
+              "access_count": 7,
+              "consumed": false
+            }
+            ```
       example:
         id: "evt_abc123def456"
         type: "qurl.accessed"
@@ -3672,8 +5284,10 @@ components:
         timestamp: "2024-01-08T10:35:00Z"
         api_version: "2024-01-01"
         data:
+          qurl_id: "q_xyz789abcdef"
           resource_id: "r_k8xqp9h2sj9"
-          access_token_id: "at_xyz789"
+          access_count: 3
+          consumed: false
           src_ip: "192.168.1.100"
           user_agent: "Mozilla/5.0..."
 
@@ -3728,6 +5342,31 @@ components:
           description: New spending cap in cents (0 = no cap)
 
     # Billing schemas
+    CreateBillingCheckoutRequest:
+      type: object
+      required:
+        - plan
+      # Reject unknown fields at the middleware layer so client typos
+      # (`plans` vs `plan`, stray `coupon`, etc.) surface as a 400 on the
+      # typo itself instead of as a confusing "missing required property"
+      # on `plan`. No forward-compat risk — server-side additions to this
+      # schema land alongside their consumers.
+      additionalProperties: false
+      properties:
+        plan:
+          type: string
+          enum:
+            - growth
+          # x-enum-varnames pins the generated constant name so the handler's
+          # switch stays robust against any future oapi-codegen single-value
+          # enum naming change. Current versions prefix by type anyway; this
+          # is cheap future-proofing, not a bug workaround.
+          x-enum-varnames: [CreateBillingCheckoutRequestPlanGrowth]
+          description: |
+            Paid plan to check out into. Only purchasable plans are
+            permitted (currently: `growth`); anything else is rejected
+            as an invalid enum value.
+
     CheckoutSessionData:
       type: object
       required:
@@ -3838,6 +5477,15 @@ components:
           type: string
           readOnly: true
           description: TXT record value for DNS verification
+        token_expires_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+          description: |
+            When the verification token expires. Omitted for domains created
+            before token expiry was introduced (those tokens never expire).
+            After expiry, use the regenerate-token endpoint to get a new one.
         acme_cname_target:
           type: string
           readOnly: true
@@ -3859,7 +5507,7 @@ components:
         ready_for_qurls:
           type: boolean
           readOnly: true
-          description: Whether this domain is ready to be used with QURLs (status is verified, provisioning_tls, or active)
+          description: Whether this domain is ready to be used with qURLs (status is verified, provisioning_tls, or active)
         dns_records:
           type: array
           readOnly: true
@@ -3953,6 +5601,65 @@ components:
         request_id:
           type: string
           description: Unique request identifier for tracing
+        tombstone:
+          # Spectral's no-$ref-siblings forbids a description
+          # alongside $ref. The referenced TombstoneInfo schema
+          # carries the full "present-only-on-410, what-it-means"
+          # description in its own description field, so the
+          # customer-facing docs render the same copy.
+          $ref: '#/components/schemas/TombstoneInfo'
+
+    TombstoneInfo:
+      type: object
+      description: |
+        Read-only metadata for a tombstoned resource. Field-level
+        documentation below spells out which resource types each
+        field surfaces on.
+
+        **Only present on 410 Gone error responses.** Although
+        `Meta.tombstone` is structurally declared on every
+        envelope's `Meta`, it is always absent from non-410
+        responses — do not branch your client on its presence
+        for non-error responses.
+
+        Returned in the `meta.tombstone` field of 410 Gone
+        responses on `GET /v1/resources/{id}`,
+        `POST /v1/resources/{id}/qurls`, and
+        `PATCH /v1/resources/{id}` once the resource's lifecycle
+        has closed.
+
+        Tombstoned resources are gated against re-mint and
+        will be hard-deleted by the API after a retention
+        window (default 90 days). Until hard-delete, this
+        metadata remains queryable as the read-only record
+        of when the lifecycle closed.
+      required:
+        - tombstoned_at
+      properties:
+        tombstoned_at:
+          type: string
+          format: date-time
+          description: When the resource's lifecycle closed.
+        final_access_count:
+          type: integer
+          format: int64
+          description: |
+            Snapshot of total accesses across all qURLs for this
+            resource at tombstone time. **Present only on `url` and
+            `tunnel` resources** — for connector-owned (transit)
+            rows the count is stripped per the redaction contract,
+            since the connector installer is not necessarily the
+            uploader and learning "was this viewed" exposes
+            sensitive viewer-fact-of-presence about uploads the
+            installer didn't make. When present, value is >= 1.
+            Absent on `url` / `tunnel` rows means either no
+            accesses occurred before closure OR the snapshot was
+            not taken — these two cases are indistinguishable on
+            the wire by design, since both collapse to the same
+            "absent" representation.
+      example:
+        tombstoned_at: "2026-01-01T00:00:00Z"
+        final_access_count: 42
 
     ListMeta:
       type: object
@@ -4048,6 +5755,126 @@ components:
         meta:
           $ref: '#/components/schemas/Meta'
 
+    AgentBootstrapRequest:
+      type: object
+      required:
+        - public_key
+      properties:
+        public_key:
+          type: string
+          description: |
+            Agent's X25519 public key, raw 32 bytes encoded as standard
+            base64 (RFC 4648 §4 — `+`/`/` alphabet, `=` padding).
+          example: "62cFrVBeF1Tl7lUAJ9MNa9lFykVf6D7mNqLaEYggFN0="
+          minLength: 44
+          maxLength: 44
+          # Standard base64 alphabet + single `=` padding (44 chars
+          # always ends in exactly one `=` for 32-byte inputs). Moves
+          # alphabet validation upstream of the strict-server handler;
+          # the service boundary's base64.StdEncoding.Strict() decode
+          # remains the load-bearing defense (defense-in-depth).
+          pattern: '^[A-Za-z0-9+/]{43}=$'
+        agent_id:
+          type: string
+          description: |
+            Optional label correlating this agent across requests
+            (matches `LAYERV_AGENT_ID` on the agent). The server
+            generates one when omitted.
+          minLength: 2
+          maxLength: 64
+          pattern: '^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$'
+          example: "prod-us-east-1"
+        hostname:
+          type: string
+          description: |
+            Optional hostname where the agent is running (audit log
+            only). If a previous bootstrap recorded a value, omitting
+            this field (or sending an empty string) preserves the
+            prior value; send a non-empty string to replace it. There
+            is no wire shape to clear a previously-set hostname back
+            to empty — audit lineage is intentionally append-only.
+          maxLength: 253
+          example: "agent-7f8c9b-prod-use1"
+        version:
+          type: string
+          description: |
+            Optional agent build version (audit log only). Same merge
+            behavior as `hostname`: omitting or sending empty preserves
+            the prior value; send a non-empty string to replace it.
+            Cannot be cleared back to empty (same audit-lineage rule).
+          maxLength: 64
+          example: "1.4.2"
+
+    AgentBootstrapData:
+      type: object
+      description: |
+        Bootstrap response payload. An agent's registration may
+        expire after roughly 90 days of inactivity; long-lived
+        agents should re-bootstrap on restart. Re-bootstrapping
+        with the same `agent_id` is safe and returns the original
+        `registered_at`.
+      required:
+        - agent_id
+        - registered_at
+        - nhp_server_peer
+      properties:
+        agent_id:
+          type: string
+          description: Label for the agent; echoes the request value, or the server-generated identifier when none was supplied.
+        registered_at:
+          type: string
+          format: date-time
+          description: |
+            RFC3339 timestamp of the first registration for this
+            `agent_id`. Re-bootstraps return the original value, not
+            the current time.
+        nhp_server_peer:
+          $ref: '#/components/schemas/NHPServerPeerInfo'
+
+    NHPServerPeerInfo:
+      type: object
+      description: |
+        Peer info the agent needs to perform its first NHP knock.
+      required:
+        - public_key_b64
+        - host
+        - port
+        - expire_time
+      properties:
+        public_key_b64:
+          type: string
+          description: NHP server X25519 public key, base64-encoded (32 raw bytes).
+          minLength: 44
+          maxLength: 44
+        host:
+          type: string
+          description: NHP server hostname or IP (no scheme).
+          example: "nhp.layerv.ai"
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+          example: 62206
+          description: NHP server UDP port.
+        expire_time:
+          type: integer
+          format: int64
+          description: |
+            Unix timestamp (seconds) at which this peer entry should be considered stale,
+            or 0 for "no client-side expiry".
+          example: 0
+
+    AgentBootstrapResponse:
+      type: object
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/AgentBootstrapData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
   responses:
     BadRequest:
       description: Invalid request parameters
@@ -4127,7 +5954,7 @@ components:
                   type: "https://api.qurl.link/problems/quota_exceeded"
                   title: "Quota Exceeded"
                   status: 403
-                  detail: "Active QURL limit reached (10/10)"
+                  detail: "Active qURL limit reached (10/10)"
                   instance: "/v1/qurls"
                   code: "quota_exceeded"
                 meta:
@@ -4144,7 +5971,7 @@ components:
               type: "https://api.qurl.link/problems/not_found"
               title: "Resource Not Found"
               status: 404
-              detail: "QURL not found"
+              detail: "qURL not found"
               instance: "/v1/qurls/01ABC123"
               code: "not_found"
             meta:
@@ -4193,7 +6020,7 @@ components:
               type: "https://api.qurl.link/problems/knock_failed"
               title: "Knock Failed"
               status: 502
-              detail: "Failed to open firewall access. The token may have been consumed."
+              detail: "Failed to grant network access. The token may have been consumed."
               instance: "/v1/resolve"
               code: "knock_failed"
             meta:

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -50,10 +50,7 @@ describe("QURLClient", () => {
 
       await customClient.getQuota();
 
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.example.com/v1/quota",
-        expect.any(Object),
-      );
+      expect(mock).toHaveBeenCalledWith("https://api.example.com/v1/quota", expect.any(Object));
     });
   });
 
@@ -65,7 +62,7 @@ describe("QURLClient", () => {
     //
     // Parameterized over both empty and whitespace-only keys so the
     // constructor's `.trim()` (the sole gate against the whitespace case)
-    // is exercised against the entire 10-method client surface, not just
+    // is exercised against the entire client surface, not just
     // a single representative method.
     const missingKeyCases: Array<[string, string]> = [
       ["empty", ""],
@@ -92,6 +89,11 @@ describe("QURLClient", () => {
           () => noKeyClient.getQuota(),
           () => noKeyClient.mintLink("r_x"),
           () => noKeyClient.batchCreate({ items: [{ target_url: "https://example.com" }] }),
+          () => noKeyClient.revokeQurlToken("r_x", "q_x"),
+          () => noKeyClient.updateQurlToken("r_x", "q_x", { extend_by: "1h" }),
+          () => noKeyClient.listResourceSessions("r_x"),
+          () => noKeyClient.terminateResourceSession("r_x", "sess_x"),
+          () => noKeyClient.terminateAllResourceSessions("r_x"),
         ];
 
         for (const call of calls) {
@@ -171,7 +173,7 @@ describe("QURLClient", () => {
         404,
       );
 
-      const err = await client.getQURL("r_nonexistent").catch((e: unknown) => e) as QURLAPIError;
+      const err = (await client.getQURL("r_nonexistent").catch((e: unknown) => e)) as QURLAPIError;
       expect(err).toBeInstanceOf(QURLAPIError);
       expect(err.statusCode).toBe(404);
       expect(err.code).toBe("not_found");
@@ -179,6 +181,38 @@ describe("QURLClient", () => {
       expect(err.type).toBe("https://api.qurl.link/problems/not_found");
       expect(err.instance).toBe("/v1/qurls/r_nonexistent");
       expect(err.requestId).toBe("req_abc123");
+    });
+
+    it("preserves tombstone metadata from 410 Gone responses", async () => {
+      stubFetch(
+        {
+          error: {
+            type: "https://api.qurl.link/problems/gone",
+            title: "Resource Gone",
+            status: 410,
+            detail: "Resource lifecycle closed",
+            instance: "/v1/resources/r_abc123def45",
+            code: "gone",
+          },
+          meta: {
+            request_id: "req_gone",
+            tombstone: {
+              tombstoned_at: "2026-06-01T00:00:00Z",
+              final_access_count: 42,
+            },
+          },
+        },
+        410,
+      );
+
+      const err = (await client.getQURL("r_abc123def45").catch((e: unknown) => e)) as QURLAPIError;
+      expect(err).toBeInstanceOf(QURLAPIError);
+      expect(err.statusCode).toBe(410);
+      expect(err.requestId).toBe("req_gone");
+      expect(err.tombstone).toEqual({
+        tombstoned_at: "2026-06-01T00:00:00Z",
+        final_access_count: 42,
+      });
     });
 
     it("throws QURLAPIError on 5xx response", async () => {
@@ -195,7 +229,7 @@ describe("QURLClient", () => {
         500,
       );
 
-      const err = await client.getQuota().catch((e: unknown) => e) as QURLAPIError;
+      const err = (await client.getQuota().catch((e: unknown) => e)) as QURLAPIError;
       expect(err).toBeInstanceOf(QURLAPIError);
       expect(err.statusCode).toBe(500);
       expect(err.code).toBe("internal_error");
@@ -203,12 +237,9 @@ describe("QURLClient", () => {
     });
 
     it("falls back to error.message for legacy error format", async () => {
-      stubFetch(
-        { error: { code: "not_found", message: "Resource not found" } },
-        404,
-      );
+      stubFetch({ error: { code: "not_found", message: "Resource not found" } }, 404);
 
-      const err = await client.getQURL("r_nonexistent").catch((e: unknown) => e) as QURLAPIError;
+      const err = (await client.getQURL("r_nonexistent").catch((e: unknown) => e)) as QURLAPIError;
       expect(err).toBeInstanceOf(QURLAPIError);
       expect(err.statusCode).toBe(404);
       expect(err.code).toBe("not_found");
@@ -232,7 +263,7 @@ describe("QURLClient", () => {
         403,
       );
 
-      const err = await client.getQuota().catch((e: unknown) => e) as QURLAPIError;
+      const err = (await client.getQuota().catch((e: unknown) => e)) as QURLAPIError;
       expect(err).toBeInstanceOf(QURLAPIError);
       expect(err.message).toBe("Forbidden");
       expect(err.type).toBe("https://api.qurl.link/problems/forbidden");
@@ -251,11 +282,14 @@ describe("QURLClient", () => {
     });
 
     it("throws QURLAPIError on non-JSON response", async () => {
-      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: () => Promise.resolve("not json at all"),
-      }));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve("not json at all"),
+        }),
+      );
 
       const err = await client.getQuota().catch((e: unknown) => e);
       expect(err).toBeInstanceOf(QURLAPIError);
@@ -267,34 +301,43 @@ describe("QURLClient", () => {
 
     it("truncates long non-JSON response in error message", async () => {
       const longText = "x".repeat(300);
-      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: () => Promise.resolve(longText),
-      }));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(longText),
+        }),
+      );
 
-      const err = await client.getQuota().catch((e: unknown) => e) as QURLAPIError;
+      const err = (await client.getQuota().catch((e: unknown) => e)) as QURLAPIError;
       expect(err).toBeInstanceOf(QURLAPIError);
       expect(err.message).toBe("Failed to parse response: " + "x".repeat(200));
     });
 
     it("handles empty 2xx response body (204 No Content)", async () => {
-      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-        ok: true,
-        status: 204,
-        text: () => Promise.resolve(""),
-      }));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 204,
+          text: () => Promise.resolve(""),
+        }),
+      );
 
       const result = await client.deleteQURL("r_abc");
       expect(result).toBeUndefined();
     });
 
     it("throws on empty non-2xx response body", async () => {
-      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-        ok: false,
-        status: 502,
-        text: () => Promise.resolve(""),
-      }));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 502,
+          text: () => Promise.resolve(""),
+        }),
+      );
 
       const err = await client.getQuota().catch((e: unknown) => e);
       expect(err).toBeInstanceOf(QURLAPIError);
@@ -477,10 +520,7 @@ describe("QURLClient", () => {
 
       await client.listQURLs({});
 
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls",
-        expect.any(Object),
-      );
+      expect(mock).toHaveBeenCalledWith("https://api.test.com/v1/qurls", expect.any(Object));
     });
 
     it("sends filter query params", async () => {
@@ -661,7 +701,7 @@ describe("QURLClient", () => {
       expect(result).toEqual(mockData);
     });
 
-    it("sends no body when no input provided", async () => {
+    it("sends an empty JSON body when no input provided", async () => {
       const mock = stubFetch({ data: { qurl_link: "https://qurl.link/at_x" } });
 
       await client.mintLink("r_abc123");
@@ -669,12 +709,11 @@ describe("QURLClient", () => {
       expect(mock).toHaveBeenCalledWith(
         "https://api.test.com/v1/qurls/r_abc123/mint_link",
         expect.objectContaining({
-          body: undefined,
+          body: JSON.stringify({}),
         }),
       );
-      // Content-Type should be omitted when there's no body.
       const headers = (mock.mock.calls[0][1] as { headers: Record<string, string> }).headers;
-      expect(headers).not.toHaveProperty("Content-Type");
+      expect(headers).toHaveProperty("Content-Type", "application/json");
     });
 
     it("URL-encodes the resource ID", async () => {
@@ -729,7 +768,11 @@ describe("QURLClient", () => {
           failed: 1,
           results: [
             { index: 0, success: true, resource_id: "r_abc", qurl_link: "https://qurl.link/at_1" },
-            { index: 1, success: false, error: { code: "invalid_target_url", message: "Invalid URL" } },
+            {
+              index: 1,
+              success: false,
+              error: { code: "invalid_target_url", message: "Invalid URL" },
+            },
           ],
         },
         meta: { request_id: "req_batch2" },
@@ -737,10 +780,7 @@ describe("QURLClient", () => {
       stubFetch(mockData, 207);
 
       const result = await client.batchCreate({
-        items: [
-          { target_url: "https://valid.example.com" },
-          { target_url: "not-a-url" },
-        ],
+        items: [{ target_url: "https://valid.example.com" }, { target_url: "not-a-url" }],
       });
 
       expect(result.data.succeeded).toBe(1);
@@ -803,6 +843,113 @@ describe("QURLClient", () => {
       await expect(
         client.batchCreate({ items: [{ target_url: "https://example.com" }] }),
       ).rejects.toThrow(QURLAPIError);
+    });
+  });
+
+  describe("resource qURL tokens", () => {
+    it("sends DELETE to /v1/resources/:id/qurls/:qurl_id", async () => {
+      const mock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 204,
+        text: () => Promise.resolve(""),
+      });
+      vi.stubGlobal("fetch", mock);
+
+      const result = await client.revokeQurlToken("r_abc123def45", "q_abc123def45");
+
+      expect(result).toBeUndefined();
+      expect(mock).toHaveBeenCalledWith(
+        "https://api.test.com/v1/resources/r_abc123def45/qurls/q_abc123def45",
+        expect.objectContaining({ method: "DELETE", body: undefined }),
+      );
+    });
+
+    it("sends PATCH to /v1/resources/:id/qurls/:qurl_id", async () => {
+      const mockData = {
+        data: {
+          qurl_id: "q_abc123def45",
+          status: "active",
+          one_time_use: false,
+          max_sessions: 5,
+          session_duration: 3600,
+          use_count: 0,
+          created_at: "2026-06-01T00:00:00Z",
+          expires_at: "2026-06-02T00:00:00Z",
+        },
+      };
+      const mock = stubFetch(mockData);
+
+      const result = await client.updateQurlToken("r_abc123def45", "q_abc123def45", {
+        max_sessions: 5,
+      });
+
+      expect(mock).toHaveBeenCalledWith(
+        "https://api.test.com/v1/resources/r_abc123def45/qurls/q_abc123def45",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ max_sessions: 5 }),
+        }),
+      );
+      expect(result).toEqual(mockData);
+    });
+
+    it("URL-encodes resource and qURL IDs", async () => {
+      const mock = stubFetch({ data: {} });
+
+      await client.updateQurlToken("r_abc/def", "q_abc/def", { label: "Alice" });
+
+      expect(mock).toHaveBeenCalledWith(
+        "https://api.test.com/v1/resources/r_abc%2Fdef/qurls/q_abc%2Fdef",
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("resource sessions", () => {
+    it("sends GET to /v1/resources/:id/sessions", async () => {
+      const mockData = {
+        data: [{ session_id: "sess_1", qurl_id: "q_abc123def45" }],
+        meta: { request_id: "req_sessions" },
+      };
+      const mock = stubFetch(mockData);
+
+      const result = await client.listResourceSessions("r_abc123def45");
+
+      expect(mock).toHaveBeenCalledWith(
+        "https://api.test.com/v1/resources/r_abc123def45/sessions",
+        expect.objectContaining({ method: "GET", body: undefined }),
+      );
+      expect(result).toEqual(mockData);
+    });
+
+    it("sends DELETE to /v1/resources/:id/sessions/:session_id", async () => {
+      const mock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 204,
+        text: () => Promise.resolve(""),
+      });
+      vi.stubGlobal("fetch", mock);
+
+      const result = await client.terminateResourceSession("r_abc123def45", "sess_1");
+
+      expect(result).toBeUndefined();
+      expect(mock).toHaveBeenCalledWith(
+        "https://api.test.com/v1/resources/r_abc123def45/sessions/sess_1",
+        expect.objectContaining({ method: "DELETE", body: undefined }),
+      );
+    });
+
+    it("sends DELETE to /v1/resources/:id/sessions for all sessions", async () => {
+      const mockData = { data: { terminated: 3 }, meta: { request_id: "req_term" } };
+      const mock = stubFetch(mockData);
+
+      const result = await client.terminateAllResourceSessions("r_abc123def45");
+
+      expect(mock).toHaveBeenCalledWith(
+        "https://api.test.com/v1/resources/r_abc123def45/sessions",
+        expect.objectContaining({ method: "DELETE", body: undefined }),
+      );
+      expect(result).toEqual(mockData);
     });
   });
 });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -84,6 +84,7 @@ describe("QURLClient", () => {
           () => noKeyClient.listQURLs(),
           () => noKeyClient.deleteQURL("r_x"),
           () => noKeyClient.updateQURL("r_x", { extend_by: "1h" }),
+          () => noKeyClient.updateResource("r_x", { custom_domain: "app.example.com" }),
           () => noKeyClient.extendQURL("r_x", { extend_by: "1h" }),
           () => noKeyClient.resolveQURL({ access_token: "at_x" }),
           () => noKeyClient.getQuota(),
@@ -612,6 +613,27 @@ describe("QURLClient", () => {
           body: JSON.stringify({ tags: ["prod", "api"], description: "Updated description" }),
         }),
       );
+    });
+  });
+
+  describe("updateResource", () => {
+    it("sends PATCH to /v1/resources/:id with resource metadata body", async () => {
+      const mockData = { data: { resource_id: "r_abc", custom_domain: "app.example.com" } };
+      const mock = stubFetch(mockData);
+
+      const result = await client.updateResource("r_abc", {
+        custom_domain: "app.example.com",
+        preserve_host: true,
+      });
+
+      expect(mock).toHaveBeenCalledWith(
+        "https://api.test.com/v1/resources/r_abc",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ custom_domain: "app.example.com", preserve_host: true }),
+        }),
+      );
+      expect(result).toEqual(mockData);
     });
   });
 

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -18,6 +18,7 @@ export function makeMockClient(overrides: Partial<IQURLClient> = {}): IQURLClien
     listQURLs: vi.fn(),
     deleteQURL: vi.fn(),
     updateQURL: vi.fn(),
+    updateResource: vi.fn(),
     extendQURL: vi.fn(),
     resolveQURL: vi.fn(),
     getQuota: vi.fn(),

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -7,6 +7,7 @@ import type {
   MintLinkOutput,
   QURL,
   ResolveOutput,
+  SessionData,
 } from "../client.js";
 import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -22,6 +23,11 @@ export function makeMockClient(overrides: Partial<IQURLClient> = {}): IQURLClien
     getQuota: vi.fn(),
     mintLink: vi.fn(),
     batchCreate: vi.fn(),
+    revokeQurlToken: vi.fn(),
+    updateQurlToken: vi.fn(),
+    listResourceSessions: vi.fn(),
+    terminateResourceSession: vi.fn(),
+    terminateAllResourceSessions: vi.fn(),
     ...overrides,
   };
 }
@@ -92,6 +98,7 @@ export function sampleResolveOutput(overrides: Partial<ResolveOutput> = {}): Res
 
 export function sampleMintLinkOutput(overrides: Partial<MintLinkOutput> = {}): MintLinkOutput {
   return {
+    qurl_id: "q_abc123def45",
     qurl_link: "https://qurl.link/at_xyz",
     expires_at: "2026-03-10T00:00:00Z",
     ...overrides,
@@ -118,5 +125,17 @@ export function sampleBatchCreateOutput(
       ...overrides,
     },
     meta: { request_id: "req_batch" },
+  };
+}
+
+export function sampleSession(overrides: Partial<SessionData> = {}): SessionData {
+  return {
+    session_id: "sess_abc123",
+    qurl_id: "q_abc123def45",
+    src_ip: "192.0.2.10",
+    user_agent: "curl/8.0.0",
+    created_at: "2026-06-01T00:00:00Z",
+    last_seen_at: "2026-06-01T00:05:00Z",
+    ...overrides,
   };
 }

--- a/src/__tests__/output-schemas.types.test.ts
+++ b/src/__tests__/output-schemas.types.test.ts
@@ -8,14 +8,18 @@ import type {
   MintLinkOutput,
   QURL,
   ResolveOutput,
+  SessionListOutput,
 } from "../client.js";
 import {
+  accessTokenOutputSchema,
   batchCreateOutputSchema,
   createQurlOutputSchema,
+  listQurlSessionsOutputSchema,
   listQurlsOutputSchema,
   mintLinkOutputSchema,
   qurlSchema,
   resolveQurlOutputSchema,
+  updateQurlTokenOutputSchema,
 } from "../tools/output-schemas.js";
 import { sampleAccessToken, sampleQURL } from "./helpers.js";
 
@@ -48,6 +52,18 @@ describe("output schema <-> client type alignment", () => {
     expectTypeOf<z.infer<typeof mintLinkOutputSchema>>().toEqualTypeOf<MintLinkOutput>();
   });
 
+  it("accessTokenOutputSchema matches AccessToken", () => {
+    expectTypeOf<z.infer<typeof accessTokenOutputSchema>>().toEqualTypeOf<AccessToken>();
+  });
+
+  it("updateQurlTokenOutputSchema matches AccessToken", () => {
+    expectTypeOf<z.infer<typeof updateQurlTokenOutputSchema>>().toEqualTypeOf<AccessToken>();
+  });
+
+  it("listQurlSessionsOutputSchema matches SessionListOutput", () => {
+    expectTypeOf<z.infer<typeof listQurlSessionsOutputSchema>>().toEqualTypeOf<SessionListOutput>();
+  });
+
   it("batchCreateOutputSchema matches the flattened BatchCreateOutput.data + request_id", () => {
     // Schema flattens the `{ data, meta }` envelope; assert against the
     // flattened shape so a new field on `BatchCreateOutput.data` is a
@@ -63,6 +79,13 @@ describe("output schema <-> client type alignment", () => {
 // Lock the behavior in so a future "fix" that removes the .catch trips
 // these tests instead of silently breaking hosts.
 describe("qurlSchema.status drift tolerance", () => {
+  it("accepts connector-owned rows that omit target_url", () => {
+    const withoutTargetURL: Record<string, unknown> = { ...sampleQURL() };
+    delete withoutTargetURL.target_url;
+    const parsed = qurlSchema.parse(withoutTargetURL);
+    expect(parsed.target_url).toBeUndefined();
+  });
+
   it("accepts 'active', 'revoked', and 'expired' as-is", () => {
     // "expired" round-trips because api-spec/qurls.yaml's
     // `QurlData.properties.status` description documents it as a real
@@ -120,9 +143,12 @@ describe("qurlSchema.status drift tolerance", () => {
     // `satisfies` gives drift insurance: removing one of these from
     // AccessToken["status"] (e.g. dropping "consumed") fails compilation
     // here instead of letting the test silently miss a documented value.
-    const documented = ["active", "consumed", "expired", "revoked"] as const satisfies ReadonlyArray<
-      AccessToken["status"]
-    >;
+    const documented = [
+      "active",
+      "consumed",
+      "expired",
+      "revoked",
+    ] as const satisfies ReadonlyArray<AccessToken["status"]>;
     for (const s of documented) {
       const parsed = qurlSchema.parse({
         ...sampleQURL(),

--- a/src/__tests__/output-schemas.types.test.ts
+++ b/src/__tests__/output-schemas.types.test.ts
@@ -60,6 +60,12 @@ describe("output schema <-> client type alignment", () => {
     expectTypeOf<z.infer<typeof updateQurlTokenOutputSchema>>().toEqualTypeOf<AccessToken>();
   });
 
+  it("accepts sparse QurlSummary responses allowed by the OpenAPI spec", () => {
+    const sparse = { qurl_id: "q_sparse12345", status: "active" };
+    expect(accessTokenOutputSchema.parse(sparse)).toEqual(sparse);
+    expect(updateQurlTokenOutputSchema.parse(sparse)).toEqual(sparse);
+  });
+
   it("listQurlSessionsOutputSchema matches SessionListOutput", () => {
     expectTypeOf<z.infer<typeof listQurlSessionsOutputSchema>>().toEqualTypeOf<SessionListOutput>();
   });

--- a/src/__tests__/resources/links.test.ts
+++ b/src/__tests__/resources/links.test.ts
@@ -45,9 +45,7 @@ describe("linksResource", () => {
 
   describe("handler", () => {
     it("calls client.listQURLs with limit 50", async () => {
-      const mockList = vi
-        .fn()
-        .mockResolvedValue({ data: sampleQURLs, meta: { has_more: false } });
+      const mockList = vi.fn().mockResolvedValue({ data: sampleQURLs, meta: { has_more: false } });
       const client = makeMockClient({ listQURLs: mockList });
       const resource = linksResource(client);
 
@@ -57,9 +55,7 @@ describe("linksResource", () => {
     });
 
     it("returns contents array with URI and mimeType", async () => {
-      const mockList = vi
-        .fn()
-        .mockResolvedValue({ data: sampleQURLs, meta: { has_more: false } });
+      const mockList = vi.fn().mockResolvedValue({ data: sampleQURLs, meta: { has_more: false } });
       const client = makeMockClient({ listQURLs: mockList });
       const resource = linksResource(client);
 
@@ -71,9 +67,7 @@ describe("linksResource", () => {
     });
 
     it("returns the data array as JSON text", async () => {
-      const mockList = vi
-        .fn()
-        .mockResolvedValue({ data: sampleQURLs, meta: { has_more: false } });
+      const mockList = vi.fn().mockResolvedValue({ data: sampleQURLs, meta: { has_more: false } });
       const client = makeMockClient({ listQURLs: mockList });
       const resource = linksResource(client);
 

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -28,11 +28,11 @@ describe("createServer", () => {
   }
 
   describe("tools", () => {
-    it("registers all 9 tools", async () => {
+    it("registers all 13 tools", async () => {
       const { client } = await connectServer();
       const { tools } = await client.listTools();
 
-      expect(tools).toHaveLength(9);
+      expect(tools).toHaveLength(13);
     });
 
     it("registers tools with correct names", async () => {
@@ -46,10 +46,14 @@ describe("createServer", () => {
         "delete_qurl",
         "extend_qurl",
         "get_qurl",
+        "list_qurl_sessions",
         "list_qurls",
         "mint_link",
         "resolve_qurl",
+        "revoke_qurl_token",
+        "terminate_qurl_sessions",
         "update_qurl",
+        "update_qurl_token",
       ]);
     });
 

--- a/src/__tests__/tdqs-metadata.test.ts
+++ b/src/__tests__/tdqs-metadata.test.ts
@@ -5,11 +5,13 @@ import type { IQURLClient } from "../client.js";
 import { toolFactories } from "../server.js";
 import {
   makeMockClient,
+  sampleAccessToken,
   sampleBatchCreateOutput,
   sampleCreateQURLData,
   sampleMintLinkOutput,
   sampleQURL,
   sampleResolveOutput,
+  sampleSession,
 } from "./helpers.js";
 
 const tools = toolFactories.map((factory) => factory(makeMockClient()));
@@ -73,6 +75,10 @@ describe("TDQS tool metadata coverage", () => {
       batch_create_qurls: ["create_qurl"],
       list_qurls: ["get_qurl", "resolve_qurl"],
       create_qurl: ["mint_link", "batch_create_qurls", "update_qurl"],
+      revoke_qurl_token: ["delete_qurl"],
+      update_qurl_token: ["update_qurl", "revoke_qurl_token"],
+      list_qurl_sessions: ["terminate_qurl_sessions", "get_qurl"],
+      terminate_qurl_sessions: ["list_qurl_sessions"],
     };
     const byName = new Map(tools.map((t) => [t.name, t]));
     for (const [name, siblings] of Object.entries(expected)) {
@@ -202,7 +208,10 @@ describe("TDQS tool metadata coverage", () => {
         expect(claimed.length, `${tool.name} Returns block parsed zero keys`).toBeGreaterThan(0);
         const schemaKeys = new Set(Object.keys(tool.outputSchema.shape));
         for (const key of claimed) {
-          expect(schemaKeys, `Returns block claims '${key}' but it isn't in ${tool.name}'s outputSchema`).toContain(key);
+          expect(
+            schemaKeys,
+            `Returns block claims '${key}' but it isn't in ${tool.name}'s outputSchema`,
+          ).toContain(key);
         }
       });
     }
@@ -229,7 +238,7 @@ describe("TDQS tool metadata coverage", () => {
       ).toContain("Defaults to 'active'");
       expect(
         description,
-        "list_qurls description must assert the active default with the phrase \"By default only `active`\"",
+        'list_qurls description must assert the active default with the phrase "By default only `active`"',
       ).toContain("By default only `active`");
     });
   });
@@ -291,7 +300,7 @@ describe("TDQS tool metadata coverage", () => {
     const byName = new Map(tools.map((t) => [t.name, t]));
 
     it("marks read-only tools as readOnlyHint", () => {
-      const readOnlyNames = new Set(["list_qurls", "get_qurl"]);
+      const readOnlyNames = new Set(["list_qurls", "get_qurl", "list_qurl_sessions"]);
       for (const tool of tools) {
         if (readOnlyNames.has(tool.name)) {
           expect(tool.annotations.readOnlyHint).toBe(true);
@@ -302,8 +311,10 @@ describe("TDQS tool metadata coverage", () => {
       }
     });
 
-    it("marks delete_qurl as destructiveHint", () => {
+    it("marks destructive tools as destructiveHint", () => {
       expect(byName.get("delete_qurl")?.annotations.destructiveHint).toBe(true);
+      expect(byName.get("revoke_qurl_token")?.annotations.destructiveHint).toBe(true);
+      expect(byName.get("terminate_qurl_sessions")?.annotations.destructiveHint).toBe(true);
     });
   });
 });
@@ -317,7 +328,7 @@ describe("TDQS tool metadata coverage", () => {
  */
 describe("structuredContent ↔ outputSchema round-trip", () => {
   type Case = {
-    // Generic over 9 schemas, so input is loosely typed; per-tool tests
+    // Generic over all tool schemas, so input is loosely typed; per-tool tests
     // exercise the strict input schema.
     input: Record<string, unknown>;
     clientOverrides: Partial<IQURLClient>;
@@ -345,24 +356,24 @@ describe("structuredContent ↔ outputSchema round-trip", () => {
       },
     },
     get_qurl: {
-      input: { resource_id: "r_test123" },
+      input: { resource_id: "r_test1234567" },
       clientOverrides: { getQURL: vi.fn().mockResolvedValue({ data: qurlFixture }) },
     },
     delete_qurl: {
-      input: { resource_id: "r_test123" },
+      input: { resource_id: "r_test1234567" },
       clientOverrides: { deleteQURL: vi.fn().mockResolvedValue(undefined) },
       textIsJson: false,
     },
     extend_qurl: {
-      input: { resource_id: "r_test123", extend_by: "24h" },
+      input: { resource_id: "r_test1234567", extend_by: "24h" },
       clientOverrides: { extendQURL: vi.fn().mockResolvedValue({ data: qurlFixture }) },
     },
     update_qurl: {
-      input: { resource_id: "r_test123", extend_by: "24h" },
+      input: { resource_id: "r_test1234567", extend_by: "24h" },
       clientOverrides: { updateQURL: vi.fn().mockResolvedValue({ data: qurlFixture }) },
     },
     mint_link: {
-      input: { resource_id: "r_test123" },
+      input: { resource_id: "r_test1234567" },
       clientOverrides: {
         mintLink: vi.fn().mockResolvedValue({ data: sampleMintLinkOutput() }),
       },
@@ -370,6 +381,36 @@ describe("structuredContent ↔ outputSchema round-trip", () => {
     batch_create_qurls: {
       input: { items: [{ target_url: "https://example.com" }] },
       clientOverrides: { batchCreate: vi.fn().mockResolvedValue(sampleBatchCreateOutput()) },
+    },
+    revoke_qurl_token: {
+      input: { resource_id: "r_test1234567", qurl_id: "q_abcdef12345" },
+      clientOverrides: { revokeQurlToken: vi.fn().mockResolvedValue(undefined) },
+    },
+    update_qurl_token: {
+      input: { resource_id: "r_test1234567", qurl_id: "q_abcdef12345", extend_by: "24h" },
+      clientOverrides: {
+        updateQurlToken: vi.fn().mockResolvedValue({
+          data: sampleAccessToken({ qurl_id: "q_abcdef12345" }),
+        }),
+      },
+    },
+    list_qurl_sessions: {
+      input: { resource_id: "r_test1234567" },
+      clientOverrides: {
+        listResourceSessions: vi.fn().mockResolvedValue({
+          data: [sampleSession()],
+          meta: { request_id: "req_sessions" },
+        }),
+      },
+    },
+    terminate_qurl_sessions: {
+      input: { resource_id: "r_test1234567" },
+      clientOverrides: {
+        terminateAllResourceSessions: vi.fn().mockResolvedValue({
+          data: { terminated: 2 },
+          meta: { request_id: "req_term" },
+        }),
+      },
     },
   };
 

--- a/src/__tests__/tools/batch-create.test.ts
+++ b/src/__tests__/tools/batch-create.test.ts
@@ -6,8 +6,23 @@ const fixture = {
   succeeded: 2,
   failed: 0,
   results: [
-    { index: 0, success: true, resource_id: "r_abc", qurl_link: "https://qurl.link/at_1" },
-    { index: 1, success: true, resource_id: "r_def", qurl_link: "https://qurl.link/at_2" },
+    {
+      index: 0,
+      success: true,
+      resource_id: "r_abc123def45",
+      qurl_link: "https://qurl.link/at_1",
+      qurl_site: "https://q_abc123def45.qurl.site",
+      expires_at: "2026-04-01T00:00:00Z",
+    },
+    {
+      index: 1,
+      success: true,
+      resource_id: "r_def123abc45",
+      qurl_link: "https://qurl.link/at_2",
+      branded_domain: "share.example.com",
+      qurl_site: "https://q_def123abc45.qurl.site",
+      expires_at: "2026-04-01T00:00:00Z",
+    },
   ],
 };
 
@@ -130,8 +145,19 @@ describe("batchCreateTool", () => {
         succeeded: 1,
         failed: 1,
         results: [
-          { index: 0, success: true, resource_id: "r_abc" },
-          { index: 1, success: false, error: { code: "invalid_target_url", message: "Invalid URL" } },
+          {
+            index: 0,
+            success: true,
+            resource_id: "r_abc123def45",
+            qurl_link: "https://qurl.link/at_1",
+            qurl_site: "https://q_abc123def45.qurl.site",
+            expires_at: "2026-04-01T00:00:00Z",
+          },
+          {
+            index: 1,
+            success: false,
+            error: { code: "invalid_target_url", message: "Invalid URL" },
+          },
         ],
       };
       const mockBatch = vi.fn().mockResolvedValue({
@@ -194,10 +220,7 @@ describe("batchCreateTool", () => {
       const tool = batchCreateTool(client);
 
       const result = await tool.handler({
-        items: [
-          { target_url: "http://a.example.com" },
-          { target_url: "http://b.example.com" },
-        ],
+        items: [{ target_url: "http://a.example.com" }, { target_url: "http://b.example.com" }],
       });
 
       expect(result.isError).toBe(true);

--- a/src/__tests__/tools/create-qurl.test.ts
+++ b/src/__tests__/tools/create-qurl.test.ts
@@ -39,6 +39,7 @@ describe("createQurlTool", () => {
 
     it("accepts all optional fields", () => {
       const result = createQurlSchema.safeParse({
+        type: "url",
         target_url: "https://example.com",
         label: "Alice from Acme",
         expires_in: "24h",

--- a/src/__tests__/tools/delete-qurl.test.ts
+++ b/src/__tests__/tools/delete-qurl.test.ts
@@ -43,7 +43,7 @@ describe("deleteQurlTool", () => {
       const result = deleteQurlSchema.safeParse({ resource_id: "q_abcdef12345" });
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.issues[0].message).toContain("Expected an r_ resource ID");
+        expect(result.error.issues[0].message).toContain("Use update_qurl or mint_link");
       }
     });
   });

--- a/src/__tests__/tools/delete-qurl.test.ts
+++ b/src/__tests__/tools/delete-qurl.test.ts
@@ -3,6 +3,8 @@ import { QURLAPIError } from "../../client.js";
 import { deleteQurlTool, deleteQurlSchema } from "../../tools/delete-qurl.js";
 import { makeMockClient } from "../helpers.js";
 
+const validResourceId = "r_abc123def45";
+
 describe("deleteQurlTool", () => {
   describe("metadata", () => {
     it("has correct name", () => {
@@ -23,7 +25,7 @@ describe("deleteQurlTool", () => {
     });
 
     it("accepts valid resource_id string", () => {
-      const result = deleteQurlSchema.safeParse({ resource_id: "r_abc" });
+      const result = deleteQurlSchema.safeParse({ resource_id: validResourceId });
       expect(result.success).toBe(true);
     });
 
@@ -38,10 +40,10 @@ describe("deleteQurlTool", () => {
     });
 
     it("rejects q_ prefix IDs (DELETE only accepts r_)", () => {
-      const result = deleteQurlSchema.safeParse({ resource_id: "q_abc123456" });
+      const result = deleteQurlSchema.safeParse({ resource_id: "q_abcdef12345" });
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.issues[0].message).toContain("delete_qurl only accepts resource IDs");
+        expect(result.error.issues[0].message).toContain("Expected an r_ resource ID");
       }
     });
   });
@@ -52,9 +54,9 @@ describe("deleteQurlTool", () => {
       const client = makeMockClient({ deleteQURL: mockDelete });
       const tool = deleteQurlTool(client);
 
-      await tool.handler({ resource_id: "r_abc123" });
+      await tool.handler({ resource_id: validResourceId });
 
-      expect(mockDelete).toHaveBeenCalledWith("r_abc123");
+      expect(mockDelete).toHaveBeenCalledWith(validResourceId);
     });
 
     it("returns confirmation message with resource_id", async () => {
@@ -62,11 +64,11 @@ describe("deleteQurlTool", () => {
       const client = makeMockClient({ deleteQURL: mockDelete });
       const tool = deleteQurlTool(client);
 
-      const result = await tool.handler({ resource_id: "r_abc123" });
+      const result = await tool.handler({ resource_id: validResourceId });
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe("text");
-      expect(result.content[0].text).toBe("qURL r_abc123 is revoked.");
+      expect(result.content[0].text).toBe(`qURL ${validResourceId} is revoked.`);
     });
 
     it("propagates client errors", async () => {
@@ -74,7 +76,7 @@ describe("deleteQurlTool", () => {
       const client = makeMockClient({ deleteQURL: mockDelete });
       const tool = deleteQurlTool(client);
 
-      await expect(tool.handler({ resource_id: "r_abc" })).rejects.toThrow("Forbidden");
+      await expect(tool.handler({ resource_id: validResourceId })).rejects.toThrow("Forbidden");
     });
 
     it("swallows 404 from a re-delete and flags was_already_revoked", async () => {
@@ -84,14 +86,14 @@ describe("deleteQurlTool", () => {
       const client = makeMockClient({ deleteQURL: mockDelete });
       const tool = deleteQurlTool(client);
 
-      const result = await tool.handler({ resource_id: "r_abc123" });
+      const result = await tool.handler({ resource_id: validResourceId });
 
-      expect(result.content[0].text).toBe("qURL r_abc123 is revoked.");
+      expect(result.content[0].text).toBe(`qURL ${validResourceId} is revoked.`);
       expect(result.structuredContent).toEqual({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         revoked: true,
         was_already_revoked: true,
-        message: "qURL r_abc123 is revoked.",
+        message: `qURL ${validResourceId} is revoked.`,
       });
     });
 
@@ -100,7 +102,7 @@ describe("deleteQurlTool", () => {
       const client = makeMockClient({ deleteQURL: mockDelete });
       const tool = deleteQurlTool(client);
 
-      const result = await tool.handler({ resource_id: "r_abc123" });
+      const result = await tool.handler({ resource_id: validResourceId });
 
       expect(result.structuredContent).toMatchObject({
         was_already_revoked: false,
@@ -114,7 +116,7 @@ describe("deleteQurlTool", () => {
       const client = makeMockClient({ deleteQURL: mockDelete });
       const tool = deleteQurlTool(client);
 
-      await expect(tool.handler({ resource_id: "r_abc" })).rejects.toThrow(
+      await expect(tool.handler({ resource_id: validResourceId })).rejects.toThrow(
         "Insufficient permissions.",
       );
     });

--- a/src/__tests__/tools/extend-qurl.test.ts
+++ b/src/__tests__/tools/extend-qurl.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect, vi } from "vitest";
 import { extendQurlTool, extendQurlSchema } from "../../tools/extend-qurl.js";
 import { makeMockClient, sampleQURL } from "../helpers.js";
 
+const validResourceId = "r_abc123def45";
+const extendResourceId = "r_extend12345";
+
 const fixture = sampleQURL({
-  resource_id: "r_extend1",
+  resource_id: extendResourceId,
   qurl_site: "https://ext.qurl.site",
   target_url: "https://example.com/extended",
   expires_at: "2026-04-09T00:00:00Z",
@@ -26,13 +29,13 @@ describe("extendQurlTool", () => {
   describe("schema", () => {
     it("requires both resource_id and extend_by", () => {
       expect(extendQurlSchema.safeParse({}).success).toBe(false);
-      expect(extendQurlSchema.safeParse({ resource_id: "r_abc" }).success).toBe(false);
+      expect(extendQurlSchema.safeParse({ resource_id: validResourceId }).success).toBe(false);
       expect(extendQurlSchema.safeParse({ extend_by: "24h" }).success).toBe(false);
     });
 
     it("accepts valid input", () => {
       const result = extendQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         extend_by: "24h",
       });
       expect(result.success).toBe(true);
@@ -40,7 +43,7 @@ describe("extendQurlTool", () => {
 
     it("rejects non-string extend_by", () => {
       const result = extendQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         extend_by: 24,
       });
       expect(result.success).toBe(false);
@@ -56,7 +59,7 @@ describe("extendQurlTool", () => {
 
     it("rejects empty extend_by", () => {
       const result = extendQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         extend_by: "",
       });
       expect(result.success).toBe(false);
@@ -69,9 +72,9 @@ describe("extendQurlTool", () => {
       const client = makeMockClient({ extendQURL: mockExtend });
       const tool = extendQurlTool(client);
 
-      await tool.handler({ resource_id: "r_extend1", extend_by: "48h" });
+      await tool.handler({ resource_id: extendResourceId, extend_by: "48h" });
 
-      expect(mockExtend).toHaveBeenCalledWith("r_extend1", { extend_by: "48h" });
+      expect(mockExtend).toHaveBeenCalledWith(extendResourceId, { extend_by: "48h" });
     });
 
     it("returns updated qURL data as formatted JSON", async () => {
@@ -79,13 +82,13 @@ describe("extendQurlTool", () => {
       const client = makeMockClient({ extendQURL: mockExtend });
       const tool = extendQurlTool(client);
 
-      const result = await tool.handler({ resource_id: "r_extend1", extend_by: "48h" });
+      const result = await tool.handler({ resource_id: extendResourceId, extend_by: "48h" });
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe("text");
 
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.resource_id).toBe("r_extend1");
+      expect(parsed.resource_id).toBe(extendResourceId);
       expect(parsed.expires_at).toBe("2026-04-09T00:00:00Z");
     });
 
@@ -94,7 +97,7 @@ describe("extendQurlTool", () => {
       const client = makeMockClient({ extendQURL: mockExtend });
       const tool = extendQurlTool(client);
 
-      const result = await tool.handler({ resource_id: "r_extend1", extend_by: "24h" });
+      const result = await tool.handler({ resource_id: extendResourceId, extend_by: "24h" });
       expect(result.content[0].text).toBe(JSON.stringify(fixture));
     });
 
@@ -104,7 +107,7 @@ describe("extendQurlTool", () => {
       const tool = extendQurlTool(client);
 
       await expect(
-        tool.handler({ resource_id: "r_expired", extend_by: "24h" }),
+        tool.handler({ resource_id: "r_expired1234", extend_by: "24h" }),
       ).rejects.toThrow("QURL expired");
     });
   });

--- a/src/__tests__/tools/get-qurl.test.ts
+++ b/src/__tests__/tools/get-qurl.test.ts
@@ -33,7 +33,12 @@ describe("getQurlTool", () => {
     });
 
     it("accepts valid resource_id string", () => {
-      const result = getQurlSchema.safeParse({ resource_id: "r_abc123" });
+      const result = getQurlSchema.safeParse({ resource_id: "r_abc123def45" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts valid qURL display ID string", () => {
+      const result = getQurlSchema.safeParse({ resource_id: "q_abcdef12345" });
       expect(result.success).toBe(true);
     });
 

--- a/src/__tests__/tools/list-qurl-sessions.test.ts
+++ b/src/__tests__/tools/list-qurl-sessions.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { listQurlSessionsTool, listQurlSessionsSchema } from "../../tools/list-qurl-sessions.js";
+import { makeMockClient, sampleSession } from "../helpers.js";
+
+const resourceId = "r_abc123def45";
+
+describe("listQurlSessionsTool", () => {
+  describe("schema", () => {
+    it("requires a valid resource_id", () => {
+      expect(listQurlSessionsSchema.safeParse({}).success).toBe(false);
+      expect(listQurlSessionsSchema.safeParse({ resource_id: "q_abc123def45" }).success).toBe(
+        false,
+      );
+      expect(listQurlSessionsSchema.safeParse({ resource_id: resourceId }).success).toBe(true);
+    });
+  });
+
+  describe("handler", () => {
+    it("calls client.listResourceSessions and returns the envelope", async () => {
+      const payload = { data: [sampleSession()], meta: { request_id: "req_sessions" } };
+      const mockList = vi.fn().mockResolvedValue(payload);
+      const tool = listQurlSessionsTool(makeMockClient({ listResourceSessions: mockList }));
+
+      const result = await tool.handler({ resource_id: resourceId });
+
+      expect(mockList).toHaveBeenCalledWith(resourceId);
+      expect(JSON.parse(result.content[0].text)).toEqual(payload);
+      expect(result.structuredContent).toEqual(payload);
+    });
+  });
+});

--- a/src/__tests__/tools/mint-link.test.ts
+++ b/src/__tests__/tools/mint-link.test.ts
@@ -3,9 +3,11 @@ import { mintLinkTool, mintLinkBaseSchema, mintLinkSchema } from "../../tools/mi
 import { makeMockClient } from "../helpers.js";
 
 const fixture = {
+  qurl_id: "q_abc123def45",
   qurl_link: "https://qurl.link/at_newtoken123",
   expires_at: "2026-04-01T00:00:00Z",
 };
+const validResourceId = "r_abc123def45";
 
 describe("mintLinkTool", () => {
   describe("metadata", () => {
@@ -33,13 +35,13 @@ describe("mintLinkTool", () => {
     });
 
     it("accepts valid resource_id", () => {
-      const result = mintLinkSchema.safeParse({ resource_id: "r_abc123" });
+      const result = mintLinkSchema.safeParse({ resource_id: validResourceId });
       expect(result.success).toBe(true);
     });
 
     it("accepts expires_in", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         expires_in: "7d",
       });
       expect(result.success).toBe(true);
@@ -47,7 +49,7 @@ describe("mintLinkTool", () => {
 
     it("accepts expires_at", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         expires_at: "2026-04-01T00:00:00Z",
       });
       expect(result.success).toBe(true);
@@ -55,7 +57,7 @@ describe("mintLinkTool", () => {
 
     it("rejects both expires_in and expires_at", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         expires_in: "7d",
         expires_at: "2026-04-01T00:00:00Z",
       });
@@ -64,7 +66,7 @@ describe("mintLinkTool", () => {
 
     it("accepts optional fields", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         label: "Alice",
         expires_in: "5m",
         one_time_use: true,
@@ -76,7 +78,7 @@ describe("mintLinkTool", () => {
 
     it("accepts access_policy", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         access_policy: {
           geo_allowlist: ["US", "CA"],
           ip_denylist: ["10.0.0.0/8"],
@@ -87,7 +89,7 @@ describe("mintLinkTool", () => {
 
     it("rejects max_sessions above 1000 (API hard limit)", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         max_sessions: 1001,
       });
       expect(result.success).toBe(false);
@@ -95,7 +97,7 @@ describe("mintLinkTool", () => {
 
     it("rejects label longer than 500 characters", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         label: "x".repeat(501),
       });
       expect(result.success).toBe(false);
@@ -103,7 +105,7 @@ describe("mintLinkTool", () => {
 
     it("rejects empty expires_in so mutual exclusion refine can't be bypassed", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         expires_in: "",
         expires_at: "2026-04-01T00:00:00Z",
       });
@@ -112,7 +114,7 @@ describe("mintLinkTool", () => {
 
     it("rejects empty session_duration", () => {
       const result = mintLinkSchema.safeParse({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         session_duration: "",
       });
       expect(result.success).toBe(false);
@@ -125,19 +127,19 @@ describe("mintLinkTool", () => {
       const client = makeMockClient({ mintLink: mockMint });
       const tool = mintLinkTool(client);
 
-      await tool.handler({ resource_id: "r_abc123", label: "Alice" });
+      await tool.handler({ resource_id: validResourceId, label: "Alice" });
 
-      expect(mockMint).toHaveBeenCalledWith("r_abc123", { label: "Alice" });
+      expect(mockMint).toHaveBeenCalledWith(validResourceId, { label: "Alice" });
     });
 
-    it("passes undefined body when only resource_id is provided", async () => {
+    it("passes an empty body when only resource_id is provided", async () => {
       const mockMint = vi.fn().mockResolvedValue({ data: fixture });
       const client = makeMockClient({ mintLink: mockMint });
       const tool = mintLinkTool(client);
 
-      await tool.handler({ resource_id: "r_abc123" });
+      await tool.handler({ resource_id: validResourceId });
 
-      expect(mockMint).toHaveBeenCalledWith("r_abc123", undefined);
+      expect(mockMint).toHaveBeenCalledWith(validResourceId, {});
     });
 
     it("returns mint data as formatted JSON", async () => {
@@ -145,12 +147,13 @@ describe("mintLinkTool", () => {
       const client = makeMockClient({ mintLink: mockMint });
       const tool = mintLinkTool(client);
 
-      const result = await tool.handler({ resource_id: "r_abc123" });
+      const result = await tool.handler({ resource_id: validResourceId });
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe("text");
 
       const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.qurl_id).toBe("q_abc123def45");
       expect(parsed.qurl_link).toBe("https://qurl.link/at_newtoken123");
       expect(parsed.expires_at).toBe("2026-04-01T00:00:00Z");
     });
@@ -160,7 +163,7 @@ describe("mintLinkTool", () => {
       const client = makeMockClient({ mintLink: mockMint });
       const tool = mintLinkTool(client);
 
-      await expect(tool.handler({ resource_id: "r_nope" })).rejects.toThrow("Not found");
+      await expect(tool.handler({ resource_id: "r_nope1234567" })).rejects.toThrow("Not found");
     });
 
     it("returns isError response when both expires_in and expires_at are provided", async () => {
@@ -169,7 +172,7 @@ describe("mintLinkTool", () => {
       const tool = mintLinkTool(client);
 
       const result = await tool.handler({
-        resource_id: "r_abc123",
+        resource_id: validResourceId,
         expires_in: "7d",
         expires_at: "2026-04-01T00:00:00Z",
       });

--- a/src/__tests__/tools/resolve-qurl.test.ts
+++ b/src/__tests__/tools/resolve-qurl.test.ts
@@ -11,10 +11,10 @@ describe("resolveQurlTool", () => {
       expect(tool.name).toBe("resolve_qurl");
     });
 
-    it("has a description mentioning resolve and firewall", () => {
+    it("has a description mentioning resolve and network access", () => {
       const tool = resolveQurlTool(makeMockClient());
       expect(tool.description.toLowerCase()).toContain("resolve");
-      expect(tool.description).toContain("firewall");
+      expect(tool.description).toContain("network access");
     });
   });
 
@@ -79,9 +79,7 @@ describe("resolveQurlTool", () => {
       const client = makeMockClient({ resolveQURL: mockResolve });
       const tool = resolveQurlTool(client);
 
-      await expect(tool.handler({ access_token: "at_expired" })).rejects.toThrow(
-        "Token expired",
-      );
+      await expect(tool.handler({ access_token: "at_expired" })).rejects.toThrow("Token expired");
     });
   });
 });

--- a/src/__tests__/tools/revoke-qurl-token.test.ts
+++ b/src/__tests__/tools/revoke-qurl-token.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { revokeQurlTokenTool, revokeQurlTokenSchema } from "../../tools/revoke-qurl-token.js";
+import { makeMockClient } from "../helpers.js";
+
+const resourceId = "r_abc123def45";
+const qurlId = "q_abc123def45";
+
+describe("revokeQurlTokenTool", () => {
+  describe("schema", () => {
+    it("requires resource_id and qurl_id", () => {
+      expect(revokeQurlTokenSchema.safeParse({}).success).toBe(false);
+      expect(revokeQurlTokenSchema.safeParse({ resource_id: resourceId }).success).toBe(false);
+      expect(revokeQurlTokenSchema.safeParse({ qurl_id: qurlId }).success).toBe(false);
+    });
+
+    it("accepts valid resource and qURL IDs", () => {
+      expect(
+        revokeQurlTokenSchema.safeParse({ resource_id: resourceId, qurl_id: qurlId }).success,
+      ).toBe(true);
+    });
+
+    it("rejects swapped ID prefixes", () => {
+      expect(
+        revokeQurlTokenSchema.safeParse({ resource_id: qurlId, qurl_id: resourceId }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("handler", () => {
+    it("calls client.revokeQurlToken and returns confirmation", async () => {
+      const mockRevoke = vi.fn().mockResolvedValue(undefined);
+      const tool = revokeQurlTokenTool(makeMockClient({ revokeQurlToken: mockRevoke }));
+
+      const result = await tool.handler({ resource_id: resourceId, qurl_id: qurlId });
+
+      expect(mockRevoke).toHaveBeenCalledWith(resourceId, qurlId);
+      expect(result.structuredContent).toEqual({
+        resource_id: resourceId,
+        qurl_id: qurlId,
+        revoked: true,
+        message: `qURL token ${qurlId} is revoked.`,
+      });
+    });
+
+    it("propagates client errors", async () => {
+      const mockRevoke = vi.fn().mockRejectedValue(new Error("not active"));
+      const tool = revokeQurlTokenTool(makeMockClient({ revokeQurlToken: mockRevoke }));
+
+      await expect(tool.handler({ resource_id: resourceId, qurl_id: qurlId })).rejects.toThrow(
+        "not active",
+      );
+    });
+  });
+});

--- a/src/__tests__/tools/terminate-qurl-sessions.test.ts
+++ b/src/__tests__/tools/terminate-qurl-sessions.test.ts
@@ -43,6 +43,17 @@ describe("terminateQurlSessionsTool", () => {
       });
     });
 
+    it("fails cleanly when the terminate-all response is malformed", async () => {
+      const mockTerminateAll = vi.fn().mockResolvedValue({ data: {} });
+      const tool = terminateQurlSessionsTool(
+        makeMockClient({ terminateAllResourceSessions: mockTerminateAll }),
+      );
+
+      await expect(tool.handler({ resource_id: resourceId })).rejects.toThrow(
+        "qURL API returned an invalid session termination response.",
+      );
+    });
+
     it("terminates one session when session_id is provided", async () => {
       const mockTerminateOne = vi.fn().mockResolvedValue(undefined);
       const tool = terminateQurlSessionsTool(

--- a/src/__tests__/tools/terminate-qurl-sessions.test.ts
+++ b/src/__tests__/tools/terminate-qurl-sessions.test.ts
@@ -49,9 +49,11 @@ describe("terminateQurlSessionsTool", () => {
         makeMockClient({ terminateAllResourceSessions: mockTerminateAll }),
       );
 
-      await expect(tool.handler({ resource_id: resourceId })).rejects.toThrow(
-        "qURL API returned an invalid session termination response.",
-      );
+      await expect(tool.handler({ resource_id: resourceId })).rejects.toMatchObject({
+        name: "QURLAPIError",
+        statusCode: 502,
+        code: "invalid_response",
+      });
     });
 
     it("terminates one session when session_id is provided", async () => {

--- a/src/__tests__/tools/terminate-qurl-sessions.test.ts
+++ b/src/__tests__/tools/terminate-qurl-sessions.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  terminateQurlSessionsTool,
+  terminateQurlSessionsSchema,
+} from "../../tools/terminate-qurl-sessions.js";
+import { makeMockClient } from "../helpers.js";
+
+const resourceId = "r_abc123def45";
+
+describe("terminateQurlSessionsTool", () => {
+  describe("schema", () => {
+    it("accepts resource_id with optional session_id", () => {
+      expect(terminateQurlSessionsSchema.safeParse({ resource_id: resourceId }).success).toBe(true);
+      expect(
+        terminateQurlSessionsSchema.safeParse({ resource_id: resourceId, session_id: "sess_1" })
+          .success,
+      ).toBe(true);
+    });
+
+    it("rejects empty session_id", () => {
+      expect(
+        terminateQurlSessionsSchema.safeParse({ resource_id: resourceId, session_id: "" }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("handler", () => {
+    it("terminates all sessions when session_id is omitted", async () => {
+      const mockTerminateAll = vi
+        .fn()
+        .mockResolvedValue({ data: { terminated: 2 }, meta: { request_id: "req_term" } });
+      const tool = terminateQurlSessionsTool(
+        makeMockClient({ terminateAllResourceSessions: mockTerminateAll }),
+      );
+
+      const result = await tool.handler({ resource_id: resourceId });
+
+      expect(mockTerminateAll).toHaveBeenCalledWith(resourceId);
+      expect(result.structuredContent).toEqual({
+        resource_id: resourceId,
+        terminated: 2,
+        message: "Terminated 2 qURL session(s).",
+      });
+    });
+
+    it("terminates one session when session_id is provided", async () => {
+      const mockTerminateOne = vi.fn().mockResolvedValue(undefined);
+      const tool = terminateQurlSessionsTool(
+        makeMockClient({ terminateResourceSession: mockTerminateOne }),
+      );
+
+      const result = await tool.handler({ resource_id: resourceId, session_id: "sess_1" });
+
+      expect(mockTerminateOne).toHaveBeenCalledWith(resourceId, "sess_1");
+      expect(result.structuredContent).toEqual({
+        resource_id: resourceId,
+        session_id: "sess_1",
+        terminated: 1,
+        message: "qURL session sess_1 is terminated.",
+      });
+    });
+  });
+});

--- a/src/__tests__/tools/update-qurl-token.test.ts
+++ b/src/__tests__/tools/update-qurl-token.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { updateQurlTokenTool, updateQurlTokenSchema } from "../../tools/update-qurl-token.js";
+import { makeMockClient, sampleAccessToken } from "../helpers.js";
+
+const resourceId = "r_abc123def45";
+const qurlId = "q_abc123def45";
+const fixture = sampleAccessToken({ qurl_id: qurlId, label: "Alice", max_sessions: 5 });
+
+describe("updateQurlTokenTool", () => {
+  describe("schema", () => {
+    it("accepts a token update", () => {
+      const result = updateQurlTokenSchema.safeParse({
+        resource_id: resourceId,
+        qurl_id: qurlId,
+        max_sessions: 5,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts empty session_duration to apply the parent cap", () => {
+      const result = updateQurlTokenSchema.safeParse({
+        resource_id: resourceId,
+        qurl_id: qurlId,
+        session_duration: "",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects both extend_by and expires_at", () => {
+      const result = updateQurlTokenSchema.safeParse({
+        resource_id: resourceId,
+        qurl_id: qurlId,
+        extend_by: "1h",
+        expires_at: "2026-06-01T00:00:00Z",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing update fields", () => {
+      const result = updateQurlTokenSchema.safeParse({
+        resource_id: resourceId,
+        qurl_id: qurlId,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("handler", () => {
+    it("calls client.updateQurlToken with path IDs and body", async () => {
+      const mockUpdate = vi.fn().mockResolvedValue({ data: fixture });
+      const tool = updateQurlTokenTool(makeMockClient({ updateQurlToken: mockUpdate }));
+
+      const result = await tool.handler({
+        resource_id: resourceId,
+        qurl_id: qurlId,
+        max_sessions: 5,
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith(resourceId, qurlId, { max_sessions: 5 });
+      expect(JSON.parse(result.content[0].text).qurl_id).toBe(qurlId);
+      expect(result.structuredContent).toEqual(fixture);
+    });
+
+    it("returns isError when refinements fail", async () => {
+      const mockUpdate = vi.fn();
+      const tool = updateQurlTokenTool(makeMockClient({ updateQurlToken: mockUpdate }));
+
+      const result = await tool.handler({ resource_id: resourceId, qurl_id: qurlId });
+
+      expect(result.isError).toBe(true);
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/tools/update-qurl.test.ts
+++ b/src/__tests__/tools/update-qurl.test.ts
@@ -256,8 +256,12 @@ describe("updateQurlTool", () => {
     });
 
     it("passes custom_domain and preserve_host to client", async () => {
-      const mockUpdate = vi.fn().mockResolvedValue({ data: fixture });
-      const client = makeMockClient({ updateQURL: mockUpdate });
+      const mockUpdateQurl = vi.fn();
+      const mockUpdateResource = vi.fn().mockResolvedValue({ data: fixture });
+      const client = makeMockClient({
+        updateQURL: mockUpdateQurl,
+        updateResource: mockUpdateResource,
+      });
       const tool = updateQurlTool(client);
 
       await tool.handler({
@@ -266,15 +270,16 @@ describe("updateQurlTool", () => {
         preserve_host: true,
       });
 
-      expect(mockUpdate).toHaveBeenCalledWith(updateResourceId, {
+      expect(mockUpdateQurl).not.toHaveBeenCalled();
+      expect(mockUpdateResource).toHaveBeenCalledWith(updateResourceId, {
         custom_domain: "app.example.com",
         preserve_host: true,
       });
     });
 
     it("passes the clear-custom_domain + preserve_host combo through verbatim", async () => {
-      const mockUpdate = vi.fn().mockResolvedValue({ data: fixture });
-      const client = makeMockClient({ updateQURL: mockUpdate });
+      const mockUpdateResource = vi.fn().mockResolvedValue({ data: fixture });
+      const client = makeMockClient({ updateResource: mockUpdateResource });
       const tool = updateQurlTool(client);
 
       await tool.handler({
@@ -283,10 +288,75 @@ describe("updateQurlTool", () => {
         preserve_host: false,
       });
 
-      expect(mockUpdate).toHaveBeenCalledWith(updateResourceId, {
+      expect(mockUpdateResource).toHaveBeenCalledWith(updateResourceId, {
         custom_domain: "",
         preserve_host: false,
       });
+    });
+
+    it("routes tags and description with custom_domain through the resource endpoint", async () => {
+      const mockUpdateQurl = vi.fn();
+      const mockUpdateResource = vi.fn().mockResolvedValue({ data: fixture });
+      const client = makeMockClient({
+        updateQURL: mockUpdateQurl,
+        updateResource: mockUpdateResource,
+      });
+      const tool = updateQurlTool(client);
+
+      await tool.handler({
+        resource_id: updateResourceId,
+        tags: ["prod"],
+        description: "New desc",
+        custom_domain: "app.example.com",
+      });
+
+      expect(mockUpdateQurl).not.toHaveBeenCalled();
+      expect(mockUpdateResource).toHaveBeenCalledWith(updateResourceId, {
+        tags: ["prod"],
+        description: "New desc",
+        custom_domain: "app.example.com",
+      });
+    });
+
+    it("rejects custom_domain when called with a q_ display ID", async () => {
+      const mockUpdateQurl = vi.fn();
+      const mockUpdateResource = vi.fn();
+      const client = makeMockClient({
+        updateQURL: mockUpdateQurl,
+        updateResource: mockUpdateResource,
+      });
+      const tool = updateQurlTool(client);
+
+      const result = await tool.handler({
+        resource_id: "q_abc123def45",
+        custom_domain: "app.example.com",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("require an r_ resource ID");
+      expect(mockUpdateQurl).not.toHaveBeenCalled();
+      expect(mockUpdateResource).not.toHaveBeenCalled();
+    });
+
+    it("rejects combining expiration changes with resource-endpoint updates", async () => {
+      const mockUpdateQurl = vi.fn();
+      const mockUpdateResource = vi.fn();
+      const client = makeMockClient({
+        updateQURL: mockUpdateQurl,
+        updateResource: mockUpdateResource,
+      });
+      const tool = updateQurlTool(client);
+
+      const result = await tool.handler({
+        resource_id: updateResourceId,
+        extend_by: "24h",
+        custom_domain: "app.example.com",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("cannot be combined with extend_by or expires_at");
+      expect(mockUpdateQurl).not.toHaveBeenCalled();
+      expect(mockUpdateResource).not.toHaveBeenCalled();
     });
 
     it("propagates client errors", async () => {

--- a/src/__tests__/tools/update-qurl.test.ts
+++ b/src/__tests__/tools/update-qurl.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect, vi } from "vitest";
 import { updateQurlTool, updateQurlSchema } from "../../tools/update-qurl.js";
 import { makeMockClient, sampleQURL } from "../helpers.js";
 
+const validResourceId = "r_abc123def45";
+const updateResourceId = "r_update12345";
+
 const fixture = sampleQURL({
-  resource_id: "r_update1",
+  resource_id: updateResourceId,
   qurl_site: "https://update.qurl.site",
   target_url: "https://example.com/updated",
   expires_at: "2026-04-09T00:00:00Z",
@@ -35,7 +38,7 @@ describe("updateQurlTool", () => {
 
     it("accepts resource_id with extend_by", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         extend_by: "24h",
       });
       expect(result.success).toBe(true);
@@ -43,7 +46,7 @@ describe("updateQurlTool", () => {
 
     it("accepts resource_id with expires_at", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         expires_at: "2026-04-01T00:00:00Z",
       });
       expect(result.success).toBe(true);
@@ -51,7 +54,7 @@ describe("updateQurlTool", () => {
 
     it("accepts tags and description", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         tags: ["prod", "api"],
         description: "Updated description",
       });
@@ -60,7 +63,7 @@ describe("updateQurlTool", () => {
 
     it("rejects more than 10 tags", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         tags: Array.from({ length: 11 }, (_, i) => `tag${i}`),
       });
       expect(result.success).toBe(false);
@@ -68,7 +71,7 @@ describe("updateQurlTool", () => {
 
     it("rejects tags longer than 50 characters", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         tags: ["x".repeat(51)],
       });
       expect(result.success).toBe(false);
@@ -76,7 +79,7 @@ describe("updateQurlTool", () => {
 
     it("rejects empty tag strings", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         tags: [""],
       });
       expect(result.success).toBe(false);
@@ -84,7 +87,7 @@ describe("updateQurlTool", () => {
 
     it("rejects tags that don't match the API pattern", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         tags: ["-invalid"], // must start with alphanumeric
       });
       expect(result.success).toBe(false);
@@ -92,7 +95,7 @@ describe("updateQurlTool", () => {
 
     it("rejects description longer than 500 characters", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         description: "x".repeat(501),
       });
       expect(result.success).toBe(false);
@@ -102,7 +105,7 @@ describe("updateQurlTool", () => {
       // The API documents `description: ""` as the way to clear the field.
       // See qurl/api/openapi.yaml -> UpdateQurlRequest.description.
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         description: "",
       });
       expect(result.success).toBe(true);
@@ -112,7 +115,7 @@ describe("updateQurlTool", () => {
       // The API documents `tags: []` as the way to clear all tags.
       // See qurl/api/openapi.yaml -> UpdateQurlRequest.tags.
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         tags: [],
       });
       expect(result.success).toBe(true);
@@ -120,7 +123,7 @@ describe("updateQurlTool", () => {
 
     it("accepts custom_domain", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         custom_domain: "app.example.com",
       });
       expect(result.success).toBe(true);
@@ -128,7 +131,7 @@ describe("updateQurlTool", () => {
 
     it('accepts custom_domain: "" to clear the field', () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         custom_domain: "",
       });
       expect(result.success).toBe(true);
@@ -136,7 +139,7 @@ describe("updateQurlTool", () => {
 
     it("rejects custom_domain longer than 253 characters", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         custom_domain: "a".repeat(254),
       });
       expect(result.success).toBe(false);
@@ -144,16 +147,16 @@ describe("updateQurlTool", () => {
 
     it("accepts preserve_host: true / false", () => {
       expect(
-        updateQurlSchema.safeParse({ resource_id: "r_abc", preserve_host: true }).success,
+        updateQurlSchema.safeParse({ resource_id: validResourceId, preserve_host: true }).success,
       ).toBe(true);
       expect(
-        updateQurlSchema.safeParse({ resource_id: "r_abc", preserve_host: false }).success,
+        updateQurlSchema.safeParse({ resource_id: validResourceId, preserve_host: false }).success,
       ).toBe(true);
     });
 
     it("rejects non-boolean preserve_host", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         preserve_host: "yes",
       });
       expect(result.success).toBe(false);
@@ -161,7 +164,7 @@ describe("updateQurlTool", () => {
 
     it("rejects non-string extend_by", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         extend_by: 24,
       });
       expect(result.success).toBe(false);
@@ -169,7 +172,7 @@ describe("updateQurlTool", () => {
 
     it("rejects both extend_by and expires_at", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         extend_by: "24h",
         expires_at: "2026-04-01T00:00:00Z",
       });
@@ -185,7 +188,7 @@ describe("updateQurlTool", () => {
 
     it("rejects update with no update fields", () => {
       const result = updateQurlSchema.safeParse({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
       });
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -206,9 +209,9 @@ describe("updateQurlTool", () => {
       const client = makeMockClient({ updateQURL: mockUpdate });
       const tool = updateQurlTool(client);
 
-      await tool.handler({ resource_id: "r_update1", extend_by: "48h" });
+      await tool.handler({ resource_id: updateResourceId, extend_by: "48h" });
 
-      expect(mockUpdate).toHaveBeenCalledWith("r_update1", { extend_by: "48h" });
+      expect(mockUpdate).toHaveBeenCalledWith(updateResourceId, { extend_by: "48h" });
     });
 
     it("returns updated qURL data as formatted JSON", async () => {
@@ -216,13 +219,13 @@ describe("updateQurlTool", () => {
       const client = makeMockClient({ updateQURL: mockUpdate });
       const tool = updateQurlTool(client);
 
-      const result = await tool.handler({ resource_id: "r_update1", extend_by: "48h" });
+      const result = await tool.handler({ resource_id: updateResourceId, extend_by: "48h" });
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe("text");
 
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.resource_id).toBe("r_update1");
+      expect(parsed.resource_id).toBe(updateResourceId);
       expect(parsed.expires_at).toBe("2026-04-09T00:00:00Z");
     });
 
@@ -231,7 +234,7 @@ describe("updateQurlTool", () => {
       const client = makeMockClient({ updateQURL: mockUpdate });
       const tool = updateQurlTool(client);
 
-      const result = await tool.handler({ resource_id: "r_update1", extend_by: "24h" });
+      const result = await tool.handler({ resource_id: updateResourceId, extend_by: "24h" });
       expect(result.content[0].text).toBe(JSON.stringify(fixture));
     });
 
@@ -241,12 +244,12 @@ describe("updateQurlTool", () => {
       const tool = updateQurlTool(client);
 
       await tool.handler({
-        resource_id: "r_update1",
+        resource_id: updateResourceId,
         tags: ["prod", "api"],
         description: "New desc",
       });
 
-      expect(mockUpdate).toHaveBeenCalledWith("r_update1", {
+      expect(mockUpdate).toHaveBeenCalledWith(updateResourceId, {
         tags: ["prod", "api"],
         description: "New desc",
       });
@@ -258,12 +261,12 @@ describe("updateQurlTool", () => {
       const tool = updateQurlTool(client);
 
       await tool.handler({
-        resource_id: "r_update1",
+        resource_id: updateResourceId,
         custom_domain: "app.example.com",
         preserve_host: true,
       });
 
-      expect(mockUpdate).toHaveBeenCalledWith("r_update1", {
+      expect(mockUpdate).toHaveBeenCalledWith(updateResourceId, {
         custom_domain: "app.example.com",
         preserve_host: true,
       });
@@ -275,12 +278,12 @@ describe("updateQurlTool", () => {
       const tool = updateQurlTool(client);
 
       await tool.handler({
-        resource_id: "r_update1",
+        resource_id: updateResourceId,
         custom_domain: "",
         preserve_host: false,
       });
 
-      expect(mockUpdate).toHaveBeenCalledWith("r_update1", {
+      expect(mockUpdate).toHaveBeenCalledWith(updateResourceId, {
         custom_domain: "",
         preserve_host: false,
       });
@@ -292,7 +295,7 @@ describe("updateQurlTool", () => {
       const tool = updateQurlTool(client);
 
       await expect(
-        tool.handler({ resource_id: "r_expired", extend_by: "24h" }),
+        tool.handler({ resource_id: "r_expired1234", extend_by: "24h" }),
       ).rejects.toThrow("QURL expired");
     });
 
@@ -302,7 +305,7 @@ describe("updateQurlTool", () => {
       const tool = updateQurlTool(client);
 
       const result = await tool.handler({
-        resource_id: "r_abc",
+        resource_id: validResourceId,
         extend_by: "24h",
         expires_at: "2026-04-01T00:00:00Z",
       });
@@ -317,7 +320,7 @@ describe("updateQurlTool", () => {
       const client = makeMockClient({ updateQURL: mockUpdate });
       const tool = updateQurlTool(client);
 
-      const result = await tool.handler({ resource_id: "r_abc" });
+      const result = await tool.handler({ resource_id: validResourceId });
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("At least one update field");

--- a/src/__tests__/wrapper-coverage.test.ts
+++ b/src/__tests__/wrapper-coverage.test.ts
@@ -6,9 +6,13 @@ import { deleteQurlTool } from "../tools/delete-qurl.js";
 import { extendQurlTool } from "../tools/extend-qurl.js";
 import { getQurlTool } from "../tools/get-qurl.js";
 import { listQurlsTool } from "../tools/list-qurls.js";
+import { listQurlSessionsTool } from "../tools/list-qurl-sessions.js";
 import { mintLinkTool } from "../tools/mint-link.js";
 import { resolveQurlTool } from "../tools/resolve-qurl.js";
+import { revokeQurlTokenTool } from "../tools/revoke-qurl-token.js";
+import { terminateQurlSessionsTool } from "../tools/terminate-qurl-sessions.js";
 import { updateQurlTool } from "../tools/update-qurl.js";
+import { updateQurlTokenTool } from "../tools/update-qurl-token.js";
 import { linksResource } from "../resources/links.js";
 import { usageResource } from "../resources/usage.js";
 import { makeMockClient } from "./helpers.js";
@@ -25,8 +29,7 @@ import { makeMockClient } from "./helpers.js";
  * also wouldn't catch the regression.
  */
 
-const missingKeyError = () =>
-  new QURLAPIError(0, "missing_api_key", MISSING_API_KEY_MESSAGE);
+const missingKeyError = () => new QURLAPIError(0, "missing_api_key", MISSING_API_KEY_MESSAGE);
 
 type ToolCase = {
   name: string;
@@ -63,13 +66,13 @@ const toolCases: ToolCase[] = [
     name: "get_qurl",
     build: getQurlTool,
     stubs: ["getQURL"],
-    input: { resource_id: "r_x" },
+    input: { resource_id: "r_test1234567" },
   },
   {
     name: "delete_qurl",
     build: deleteQurlTool,
     stubs: ["deleteQURL"],
-    input: { resource_id: "r_x" },
+    input: { resource_id: "r_test1234567" },
   },
   {
     name: "extend_qurl",
@@ -77,25 +80,49 @@ const toolCases: ToolCase[] = [
     // assertion holds whether or not the delegation is preserved.
     build: extendQurlTool,
     stubs: ["extendQURL", "updateQURL"],
-    input: { resource_id: "r_x", extend_by: "1h" },
+    input: { resource_id: "r_test1234567", extend_by: "1h" },
   },
   {
     name: "update_qurl",
     build: updateQurlTool,
     stubs: ["updateQURL"],
-    input: { resource_id: "r_x", extend_by: "1h" },
+    input: { resource_id: "r_test1234567", extend_by: "1h" },
   },
   {
     name: "mint_link",
     build: mintLinkTool,
     stubs: ["mintLink"],
-    input: { resource_id: "r_x" },
+    input: { resource_id: "r_test1234567" },
   },
   {
     name: "batch_create_qurls",
     build: batchCreateTool,
     stubs: ["batchCreate"],
     input: { items: [{ target_url: "https://example.com" }] },
+  },
+  {
+    name: "revoke_qurl_token",
+    build: revokeQurlTokenTool,
+    stubs: ["revokeQurlToken"],
+    input: { resource_id: "r_test1234567", qurl_id: "q_abcdef12345" },
+  },
+  {
+    name: "update_qurl_token",
+    build: updateQurlTokenTool,
+    stubs: ["updateQurlToken"],
+    input: { resource_id: "r_test1234567", qurl_id: "q_abcdef12345", extend_by: "1h" },
+  },
+  {
+    name: "list_qurl_sessions",
+    build: listQurlSessionsTool,
+    stubs: ["listResourceSessions"],
+    input: { resource_id: "r_test1234567" },
+  },
+  {
+    name: "terminate_qurl_sessions",
+    build: terminateQurlSessionsTool,
+    stubs: ["terminateAllResourceSessions"],
+    input: { resource_id: "r_test1234567" },
   },
 ];
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,14 +22,14 @@ export interface AccessToken {
   // parent resource. See qurl/api/openapi.yaml -> QurlSummary.status.
   // `"unknown"` is the same drift sentinel as on QURL.status below.
   status: "active" | "consumed" | "expired" | "revoked" | "unknown";
-  one_time_use: boolean;
-  max_sessions: number;
-  session_duration: number;
-  use_count: number;
+  one_time_use?: boolean;
+  max_sessions?: number;
+  session_duration?: number;
+  use_count?: number;
   qurl_site?: string;
   access_policy?: AccessPolicy;
-  created_at: string;
-  expires_at: string;
+  created_at?: string;
+  expires_at?: string;
 }
 
 export interface SessionData {

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,11 @@ export interface QURLClientConfig {
 
 // --- Response data types ---
 
+export interface TombstoneInfo {
+  tombstoned_at: string;
+  final_access_count?: number;
+}
+
 export interface AccessToken {
   qurl_id: string;
   label?: string;
@@ -27,10 +32,21 @@ export interface AccessToken {
   expires_at: string;
 }
 
+export interface SessionData {
+  session_id: string;
+  qurl_id?: string;
+  src_ip?: string;
+  user_agent?: string;
+  created_at?: string;
+  last_seen_at?: string;
+}
+
 export interface QURL {
   resource_id: string;
   qurl_site?: string;
-  target_url: string;
+  // Connector-owned resources intentionally omit target_url from management
+  // reads. The field is absent rather than serialized as null.
+  target_url?: string;
   description?: string;
   tags?: string[];
   expires_at: string;
@@ -45,6 +61,7 @@ export interface QURL {
   // note.
   status: "active" | "revoked" | "expired" | "unknown";
   custom_domain?: string | null;
+  slug?: string;
   preserve_host?: boolean;
   qurl_count?: number;
   qurls?: AccessToken[];
@@ -54,9 +71,11 @@ export interface CreateQURLData {
   qurl_id: string;
   resource_id: string;
   qurl_link: string;
+  branded_domain?: string;
   qurl_site: string;
   expires_at: string;
   label?: string;
+  type?: string;
 }
 
 export interface AIAgentPolicy {
@@ -78,6 +97,8 @@ export interface AccessPolicy {
 // --- Input types ---
 
 export interface CreateQURLInput {
+  /** Resource type for integrations that are allowed to mint non-url qURLs. Defaults to "url". */
+  type?: string;
   target_url: string;
   label?: string;
   expires_in?: string;
@@ -138,6 +159,15 @@ export interface BatchCreateInput {
   items: CreateQURLInput[];
 }
 
+export interface UpdateQurlTokenInput {
+  extend_by?: string;
+  expires_at?: string;
+  label?: string;
+  access_policy?: AccessPolicy;
+  max_sessions?: number;
+  session_duration?: string;
+}
+
 // --- Output types ---
 
 export interface ListQURLsOutput {
@@ -182,8 +212,11 @@ export interface QuotaOutput {
 }
 
 export interface MintLinkOutput {
+  qurl_id: string;
   qurl_link: string;
+  branded_domain?: string;
   expires_at: string;
+  type?: string;
 }
 
 // Discriminated on `success` so consumers narrowing on the boolean get
@@ -197,6 +230,7 @@ export type BatchItemResult =
       success: true;
       resource_id: string;
       qurl_link: string;
+      branded_domain?: string;
       qurl_site: string;
       expires_at: string;
     }
@@ -216,6 +250,22 @@ export interface BatchCreateOutput {
     results: BatchItemResult[];
   };
   meta: {
+    request_id?: string;
+  };
+}
+
+export interface SessionListOutput {
+  data: SessionData[];
+  meta?: {
+    request_id?: string;
+  };
+}
+
+export interface SessionTerminateOutput {
+  data: {
+    terminated: number;
+  };
+  meta?: {
     request_id?: string;
   };
 }
@@ -243,6 +293,15 @@ export interface IQURLClient {
   getQuota(): Promise<{ data: QuotaOutput }>;
   mintLink(id: string, input?: MintLinkInput): Promise<{ data: MintLinkOutput }>;
   batchCreate(input: BatchCreateInput): Promise<BatchCreateOutput>;
+  revokeQurlToken(resourceId: string, qurlId: string): Promise<void>;
+  updateQurlToken(
+    resourceId: string,
+    qurlId: string,
+    input: UpdateQurlTokenInput,
+  ): Promise<{ data: AccessToken }>;
+  listResourceSessions(resourceId: string): Promise<SessionListOutput>;
+  terminateResourceSession(resourceId: string, sessionId: string): Promise<void>;
+  terminateAllResourceSessions(resourceId: string): Promise<SessionTerminateOutput>;
 }
 
 // --- Error class ---
@@ -263,6 +322,7 @@ export class QURLAPIError extends Error {
     public type?: string,
     public instance?: string,
     public requestId?: string,
+    public tombstone?: TombstoneInfo,
   ) {
     super(message);
     this.name = "QURLAPIError";
@@ -342,9 +402,16 @@ export class QURLClient implements IQURLClient {
       // the API documents. The fallback chain below tolerates missing fields,
       // so a malformed error response still degrades to `HTTP ${status}`.
       const error = json.error as
-        | { type?: string; title?: string; detail?: string; code?: string; message?: string; instance?: string }
+        | {
+            type?: string;
+            title?: string;
+            detail?: string;
+            code?: string;
+            message?: string;
+            instance?: string;
+          }
         | undefined;
-      const meta = json.meta as { request_id?: string } | undefined;
+      const meta = json.meta as { request_id?: string; tombstone?: TombstoneInfo } | undefined;
       throw new QURLAPIError(
         response.status,
         error?.code ?? "unknown",
@@ -352,6 +419,7 @@ export class QURLClient implements IQURLClient {
         error?.type,
         error?.instance,
         meta?.request_id,
+        meta?.tombstone,
       );
     }
 
@@ -372,6 +440,14 @@ export class QURLClient implements IQURLClient {
 
   private qurlPath(id: string): string {
     return `/v1/qurls/${encodeURIComponent(id)}`;
+  }
+
+  private resourcePath(id: string): string {
+    return `/v1/resources/${encodeURIComponent(id)}`;
+  }
+
+  private resourceQurlPath(resourceId: string, qurlId: string): string {
+    return `${this.resourcePath(resourceId)}/qurls/${encodeURIComponent(qurlId)}`;
   }
 
   async createQURL(input: CreateQURLInput): Promise<{ data: CreateQURLData }> {
@@ -420,11 +496,38 @@ export class QURLClient implements IQURLClient {
   }
 
   async mintLink(id: string, input?: MintLinkInput): Promise<{ data: MintLinkOutput }> {
-    return this.request("POST", `${this.qurlPath(id)}/mint_link`, input);
+    return this.request("POST", `${this.qurlPath(id)}/mint_link`, input ?? {});
   }
 
   async batchCreate(input: BatchCreateInput): Promise<BatchCreateOutput> {
     // 400 carries per-item errors (see request() JSDoc).
     return this.request("POST", "/v1/qurls/batch", input, [400]);
+  }
+
+  async revokeQurlToken(resourceId: string, qurlId: string): Promise<void> {
+    await this.request("DELETE", this.resourceQurlPath(resourceId, qurlId));
+  }
+
+  async updateQurlToken(
+    resourceId: string,
+    qurlId: string,
+    input: UpdateQurlTokenInput,
+  ): Promise<{ data: AccessToken }> {
+    return this.request("PATCH", this.resourceQurlPath(resourceId, qurlId), input);
+  }
+
+  async listResourceSessions(resourceId: string): Promise<SessionListOutput> {
+    return this.request("GET", `${this.resourcePath(resourceId)}/sessions`);
+  }
+
+  async terminateResourceSession(resourceId: string, sessionId: string): Promise<void> {
+    await this.request(
+      "DELETE",
+      `${this.resourcePath(resourceId)}/sessions/${encodeURIComponent(sessionId)}`,
+    );
+  }
+
+  async terminateAllResourceSessions(resourceId: string): Promise<SessionTerminateOutput> {
+    return this.request("DELETE", `${this.resourcePath(resourceId)}/sessions`);
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -133,6 +133,11 @@ export interface UpdateQURLInput {
   expires_at?: string;
   tags?: string[];
   description?: string;
+}
+
+export interface UpdateResourceInput {
+  tags?: string[];
+  description?: string;
   custom_domain?: string;
   preserve_host?: boolean;
 }
@@ -288,6 +293,7 @@ export interface IQURLClient {
   listQURLs(input?: ListQURLsInput): Promise<ListQURLsOutput>;
   deleteQURL(id: string): Promise<void>;
   updateQURL(id: string, input: UpdateQURLInput): Promise<{ data: QURL }>;
+  updateResource(id: string, input: UpdateResourceInput): Promise<{ data: QURL }>;
   extendQURL(id: string, input: ExtendQURLInput): Promise<{ data: QURL }>;
   resolveQURL(input: ResolveInput): Promise<{ data: ResolveOutput }>;
   getQuota(): Promise<{ data: QuotaOutput }>;
@@ -479,6 +485,10 @@ export class QURLClient implements IQURLClient {
 
   async updateQURL(id: string, input: UpdateQURLInput): Promise<{ data: QURL }> {
     return this.request("PATCH", this.qurlPath(id), input);
+  }
+
+  async updateResource(id: string, input: UpdateResourceInput): Promise<{ data: QURL }> {
+    return this.request("PATCH", this.resourcePath(id), input);
   }
 
   async extendQURL(id: string, input: ExtendQURLInput): Promise<{ data: QURL }> {

--- a/src/prompts/secure-a-service.ts
+++ b/src/prompts/secure-a-service.ts
@@ -3,14 +3,8 @@ import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 
 export const secureAServiceArgs = {
   target_url: z.string().describe("The URL of the service to protect with qURL"),
-  label: z
-    .string()
-    .optional()
-    .describe("Human-readable label identifying who this qURL is for"),
-  description: z
-    .string()
-    .optional()
-    .describe("Human-readable description of what this service is"),
+  label: z.string().optional().describe("Human-readable label identifying who this qURL is for"),
+  description: z.string().optional().describe("Human-readable description of what this service is"),
   expires_in: z
     .string()
     .optional()
@@ -23,7 +17,7 @@ export const secureAServiceArgs = {
     .string()
     .regex(/^[1-9]\d*$/, "Must be a positive integer")
     .optional()
-    .describe("Maximum number of concurrent sessions (e.g., \"1\", \"5\")"),
+    .describe('Maximum number of concurrent sessions (e.g., "1", "5")'),
   session_duration: z
     .string()
     .optional()
@@ -31,7 +25,9 @@ export const secureAServiceArgs = {
   ip_allowlist: z
     .string()
     .optional()
-    .describe("Comma-separated IP addresses or CIDR ranges allowed to access (e.g., \"10.0.0.0/8,192.168.1.1\")"),
+    .describe(
+      'Comma-separated IP addresses or CIDR ranges allowed to access (e.g., "10.0.0.0/8,192.168.1.1")',
+    ),
   ip_denylist: z
     .string()
     .optional()
@@ -39,11 +35,11 @@ export const secureAServiceArgs = {
   geo_allowlist: z
     .string()
     .optional()
-    .describe("Comma-separated ISO 3166-1 alpha-2 country codes allowed (e.g., \"US,CA,GB\")"),
+    .describe('Comma-separated ISO 3166-1 alpha-2 country codes allowed (e.g., "US,CA,GB")'),
   geo_denylist: z
     .string()
     .optional()
-    .describe("Comma-separated country codes to block (e.g., \"CN,RU\")"),
+    .describe('Comma-separated country codes to block (e.g., "CN,RU")'),
   block_ai_agents: z
     .enum(["true", "false"])
     .optional()
@@ -108,9 +104,7 @@ export function secureAServicePrompt() {
       if (geoDeny) policy.geo_denylist = geoDeny;
       if (blockAI) policy.ai_agent_policy = { block_all: true };
 
-      const policyLines = hasPolicy
-        ? [`- access_policy: ${JSON.stringify(policy)}`]
-        : [];
+      const policyLines = hasPolicy ? [`- access_policy: ${JSON.stringify(policy)}`] : [];
 
       const descriptionFollowUp = args.description
         ? [

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,10 @@ import { extendQurlTool } from "./tools/extend-qurl.js";
 import { updateQurlTool } from "./tools/update-qurl.js";
 import { mintLinkTool } from "./tools/mint-link.js";
 import { batchCreateTool } from "./tools/batch-create.js";
+import { revokeQurlTokenTool } from "./tools/revoke-qurl-token.js";
+import { updateQurlTokenTool } from "./tools/update-qurl-token.js";
+import { listQurlSessionsTool } from "./tools/list-qurl-sessions.js";
+import { terminateQurlSessionsTool } from "./tools/terminate-qurl-sessions.js";
 import type { ToolAnnotations } from "./tools/_shared.js";
 import { linksResource } from "./resources/links.js";
 import { usageResource } from "./resources/usage.js";
@@ -48,6 +52,10 @@ export const toolFactories = [
   updateQurlTool,
   mintLinkTool,
   batchCreateTool,
+  revokeQurlTokenTool,
+  updateQurlTokenTool,
+  listQurlSessionsTool,
+  terminateQurlSessionsTool,
 ] satisfies ToolFactory[];
 
 export function createServer(client: IQURLClient, version: string): McpServer {

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -106,8 +106,8 @@ export function zodErrorToToolResult(error: ZodError) {
  *
  * The API accepts both a resource ID (r_ prefix) and a qURL display ID
  * (q_ prefix) on get/update/extend/mint_link, and resolves a q_ ID to its
- * parent resource automatically. DELETE is the one exception — it only
- * accepts r_ IDs and defines its own schema.
+ * parent resource automatically. Resource-scoped endpoints use the
+ * narrower `resourceOnlyIdSchema` / `qurlDisplayIdSchema` helpers below.
  *
  * Rejects empty strings so a malformed call can't hit `/v1/qurls/` with
  * an empty path segment.
@@ -115,9 +115,26 @@ export function zodErrorToToolResult(error: ZodError) {
 export function resourceIdSchema(verb: string) {
   return z
     .string()
-    .min(1)
+    .regex(
+      /^(r_[a-z0-9_-]{11}|q_[0-9a-f]{11})$/,
+      "Expected an r_ resource ID or q_ qURL display ID",
+    )
     .describe(
       `The resource ID (r_ prefix) or qURL display ID (q_ prefix) to ${verb}. ` +
         "If a q_ ID is passed, the API resolves it to the parent resource automatically.",
     );
+}
+
+export function resourceOnlyIdSchema(verb: string) {
+  return z
+    .string()
+    .regex(/^r_[a-z0-9_-]{11}$/, "Expected an r_ resource ID")
+    .describe(`The resource ID (r_ prefix) to ${verb}.`);
+}
+
+export function qurlDisplayIdSchema(verb: string) {
+  return z
+    .string()
+    .regex(/^q_[0-9a-f]{11}$/, "Expected a q_ qURL display ID")
+    .describe(`The qURL display ID (q_ prefix) to ${verb}.`);
 }

--- a/src/tools/batch-create.ts
+++ b/src/tools/batch-create.ts
@@ -30,6 +30,7 @@ export function batchCreateTool(client: IQURLClient) {
       "Use this when you need to mint many qURLs at once (e.g. provisioning a vendor list, distributing per-customer share links). " +
       "Use `create_qurl` for a single resource. " +
       "**Response shape:** `{ succeeded: number, failed: number, results: BatchItemResult[], request_id?: string }`. Each `results[i]` carries `index` (matching the input position), `success`, plus either `qurl_link` + `resource_id` + `qurl_site` + `expires_at` (success) OR `error: { code, message }` (failure). " +
+      "Successful items may also carry `branded_domain` for custom-domain anchor text. " +
       "**Partial failure signaling:** the handler sets `isError: true` on the tool response whenever `failed > 0`, so agents can branch without parsing JSON. The HTTP layer also returns 400 when every item fails — that's surfaced through the same shape (read `data.results[*].error`). " +
       "**One-shot links:** like `create_qurl`, every `qurl_link` in the response is shown ONCE. Don't lose them.",
     inputSchema: batchCreateSchema,

--- a/src/tools/create-qurl.ts
+++ b/src/tools/create-qurl.ts
@@ -16,14 +16,8 @@ export const aiAgentPolicySchema = z.object({
 });
 
 export const accessPolicySchema = z.object({
-  ip_allowlist: z
-    .array(z.string())
-    .optional()
-    .describe("Allowed IP addresses or CIDR ranges"),
-  ip_denylist: z
-    .array(z.string())
-    .optional()
-    .describe("Denied IP addresses or CIDR ranges"),
+  ip_allowlist: z.array(z.string()).optional().describe("Allowed IP addresses or CIDR ranges"),
+  ip_denylist: z.array(z.string()).optional().describe("Denied IP addresses or CIDR ranges"),
   geo_allowlist: z
     .array(z.string())
     .optional()
@@ -32,29 +26,23 @@ export const accessPolicySchema = z.object({
     .array(z.string())
     .optional()
     .describe("Denied country codes (ISO 3166-1 alpha-2)"),
-  user_agent_allow_regex: z
-    .string()
-    .optional()
-    .describe("Regex to allow matching user agents"),
-  user_agent_deny_regex: z
-    .string()
-    .optional()
-    .describe("Regex to deny matching user agents"),
+  user_agent_allow_regex: z.string().optional().describe("Regex to allow matching user agents"),
+  user_agent_deny_regex: z.string().optional().describe("Regex to deny matching user agents"),
   ai_agent_policy: aiAgentPolicySchema.optional().describe("Structured AI agent access control"),
 });
 
 export const createQurlSchema = z.object({
+  type: z
+    .string()
+    .optional()
+    .describe("Resource type for integrations allowed to mint non-url qURLs. Defaults to url."),
   target_url: z.string().url().describe("The URL to protect with qURL"),
   label: z
     .string()
     .max(500)
     .optional()
     .describe("Human-readable label identifying who this qURL is for (max 500 chars)"),
-  expires_in: z
-    .string()
-    .min(1)
-    .optional()
-    .describe('Duration string (e.g., "1h", "24h", "7d")'),
+  expires_in: z.string().min(1).optional().describe('Duration string (e.g., "1h", "24h", "7d")'),
   one_time_use: z.boolean().optional().describe("Whether the link can only be used once"),
   max_sessions: z
     .number()
@@ -62,12 +50,17 @@ export const createQurlSchema = z.object({
     .min(0)
     .max(1000)
     .optional()
-    .describe("Maximum concurrent sessions (0 = unlimited, max 1000)"),
+    .describe(
+      "Maximum concurrent sessions for this qURL token (0 = unlimited when one_time_use is explicitly false; max 1000)",
+    ),
   session_duration: z
     .string()
     .min(1)
     .optional()
-    .describe('How long access lasts after clicking (e.g., "1h")'),
+    .describe(
+      'How long access lasts after the recipient reaches the content (e.g., "1h"). ' +
+        "This anchors the resource-level session-duration cap when a new resource is created.",
+    ),
   custom_domain: z
     .string()
     .max(253)
@@ -83,16 +76,17 @@ export function createQurlTool(client: IQURLClient) {
     name: "create_qurl",
     title: "Create qURL",
     description:
-      "Create a new qURL — a policy-bound, expiring access link that gates a target URL with optional IP/geo/UA/AI-agent filters and time or session limits. " +
-      "**When to use:** minting a fresh protected resource for share-once or time-limited access (e.g. send a customer a 24-hour download link, gate a doc behind an IP allowlist, distribute a one-time-use credential to a contractor). " +
-      "**When NOT to use:** use `mint_link` when you already have a resource (`r_…`) and just need an additional access token under it — `create_qurl` always creates a new resource. " +
+      "Create a qURL — a policy-bound, expiring access link that gates a target URL with optional IP/geo/UA/AI-agent filters and time or session limits. " +
+      "**When to use:** minting a fresh protected access link for share-once or time-limited access (e.g. send a customer a 24-hour download link, gate a doc behind an IP allowlist, distribute a one-time-use credential to a contractor). " +
+      "**When NOT to use:** use `mint_link` when you already have a resource (`r_…`) and just need an additional access token under it — `create_qurl` identifies the resource by target URL and may return an existing same-type resource grouping. " +
       "Use `batch_create_qurls` to create many in one round-trip. " +
       "Use `update_qurl` to retag or extend an existing resource without minting a new one. " +
-      "**Behavior:** not idempotent — calling twice produces two distinct resources (this tool doesn't surface the underlying API's `Idempotency-Key` header). " +
+      "**Behavior:** not idempotent — calling twice produces two distinct qURL tokens, though both may share the same `resource_id` when the target URL groups to an existing same-type resource (this tool doesn't surface the underlying API's `Idempotency-Key` header). " +
       "The returned `qurl_link` is shown ONCE in this response and is never recoverable through `get_qurl` or `list_qurls`; persist or share it immediately. " +
-      "The newly created resource is in `active` status with the policy and limits applied. " +
+      "A returned resource is in `active` status with the policy and per-token limits applied. " +
       "If `expires_in` is omitted the API defaults to **24h** — do not assume the link is permanent. " +
-      "**Returns:** `{ qurl_id: string (q_…), resource_id: string (r_…), qurl_link: string (shown once), qurl_site: string, expires_at: string (RFC 3339), label?: string }`. " +
+      "`max_sessions` is per minted qURL, not resource-wide; set `one_time_use: false` explicitly when you need `max_sessions: 0` to mean unlimited visitors. " +
+      "**Returns:** `{ qurl_id: string (q_…), resource_id: string (r_…), qurl_link: string (shown once), branded_domain?: string, qurl_site: string, expires_at: string (RFC 3339), label?: string, type?: string }`. " +
       "`qurl_id` is the only `q_…` display ID an agent gets in this response — keep it if you plan a follow-up against `get_qurl`/`update_qurl`/`mint_link` (which accept either prefix). " +
       "Example: `create_qurl({ target_url: 'https://example.com/private', expires_in: '24h', one_time_use: true, access_policy: { geo_allowlist: ['US'] } })`.",
     inputSchema: createQurlSchema,

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { type IQURLClient, QURLAPIError } from "../client.js";
-import { withMissingApiKeyHandler } from "./_shared.js";
+import { resourceOnlyIdSchema, withMissingApiKeyHandler } from "./_shared.js";
 import { deleteQurlOutputSchema } from "./output-schemas.js";
 
 export const deleteQurlSchema = z.object({
@@ -8,13 +8,9 @@ export const deleteQurlSchema = z.object({
   // get/update/extend/mint_link which also accept q_ prefixes. Reject
   // non-r_ IDs at the schema boundary so agents get a clear error
   // instead of a confusing API-side rejection.
-  resource_id: z
-    .string()
-    .min(1)
-    .startsWith("r_", "delete_qurl only accepts resource IDs (r_ prefix). Use update_qurl or mint_link for q_ IDs.")
-    .describe(
-      "The resource ID (must start with r_). delete_qurl does not accept q_ (qURL display) IDs.",
-    ),
+  resource_id: resourceOnlyIdSchema("delete").describe(
+    "The resource ID (r_ prefix). delete_qurl does not accept q_ (qURL display) IDs.",
+  ),
 });
 
 export function deleteQurlTool(client: IQURLClient) {
@@ -29,7 +25,7 @@ export function deleteQurlTool(client: IQURLClient) {
       "**Idempotent:** the API returns 404 for re-deletes, never-existed IDs, and resources owned by another API key (ownership-mismatch is collapsed into 404 server-side to avoid existence disclosure); this tool swallows all three. " +
       "Branch on `was_already_revoked` to distinguish the no-op case from a successful revoke on this call. " +
       "When the ID came from user input and ownership matters, call `get_qurl` first — a 200 confirms ownership; a thrown 404 is equally ambiguous on that endpoint too. " +
-      "Returns a confirmation payload. By default the resource is excluded from `list_qurls`; pass `status: \"revoked\"` to see it.",
+      'Returns a confirmation payload. By default the resource is excluded from `list_qurls`; pass `status: "revoked"` to see it.',
     inputSchema: deleteQurlSchema,
     outputSchema: deleteQurlOutputSchema,
     annotations: {

--- a/src/tools/delete-qurl.ts
+++ b/src/tools/delete-qurl.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { type IQURLClient, QURLAPIError } from "../client.js";
-import { resourceOnlyIdSchema, withMissingApiKeyHandler } from "./_shared.js";
+import { withMissingApiKeyHandler } from "./_shared.js";
 import { deleteQurlOutputSchema } from "./output-schemas.js";
 
 export const deleteQurlSchema = z.object({
@@ -8,9 +8,13 @@ export const deleteQurlSchema = z.object({
   // get/update/extend/mint_link which also accept q_ prefixes. Reject
   // non-r_ IDs at the schema boundary so agents get a clear error
   // instead of a confusing API-side rejection.
-  resource_id: resourceOnlyIdSchema("delete").describe(
-    "The resource ID (r_ prefix). delete_qurl does not accept q_ (qURL display) IDs.",
-  ),
+  resource_id: z
+    .string()
+    .regex(
+      /^r_[a-z0-9_-]{11}$/,
+      "delete_qurl only accepts resource IDs (r_ prefix). Use update_qurl or mint_link for q_ IDs.",
+    )
+    .describe("The resource ID (r_ prefix). delete_qurl does not accept q_ (qURL display) IDs."),
 });
 
 export function deleteQurlTool(client: IQURLClient) {

--- a/src/tools/get-qurl.ts
+++ b/src/tools/get-qurl.ts
@@ -16,7 +16,7 @@ export function getQurlTool(client: IQURLClient) {
       "Use this when you have a specific resource ID (r_ prefix) or qURL display ID (q_ prefix) — q_ IDs are auto-resolved to their parent resource. " +
       "Use `list_qurls` instead when you need to discover qURLs by status, date range, or search query. " +
       "Use `resolve_qurl` instead when you have an end-user access token (at_ prefix) and need to redeem it for the underlying URL. " +
-      "`qurls[]` is an unordered preview capped by the API and may be omitted on list views, preview lookup failure, or redacted connector-owned resources; use `qurl_count` to detect that more token rows may exist. " +
+      "`qurls[]` is an unordered preview capped by the API at 100 rows and may be omitted on list views, preview lookup failure, or redacted connector-owned resources; use `qurl_count` to detect that more token rows may exist. " +
       "The one-shot `qurl_link` from creation is never returned here.",
     inputSchema: getQurlSchema,
     outputSchema: getQurlOutputSchema,

--- a/src/tools/get-qurl.ts
+++ b/src/tools/get-qurl.ts
@@ -12,11 +12,12 @@ export function getQurlTool(client: IQURLClient) {
     name: "get_qurl",
     title: "Get qURL",
     description:
-      "Fetch a single qURL resource by ID and return its current state plus all access tokens. " +
+      "Fetch a single qURL resource by ID and return its current state plus a bounded preview of access tokens. " +
       "Use this when you have a specific resource ID (r_ prefix) or qURL display ID (q_ prefix) — q_ IDs are auto-resolved to their parent resource. " +
       "Use `list_qurls` instead when you need to discover qURLs by status, date range, or search query. " +
       "Use `resolve_qurl` instead when you have an end-user access token (at_ prefix) and need to redeem it for the underlying URL. " +
-      "Returns the resource shape with embedded `qurls[]` (per-token state); the one-shot `qurl_link` from creation is never returned here.",
+      "`qurls[]` is an unordered preview capped by the API and may be omitted on list views, preview lookup failure, or redacted connector-owned resources; use `qurl_count` to detect that more token rows may exist. " +
+      "The one-shot `qurl_link` from creation is never returned here.",
     inputSchema: getQurlSchema,
     outputSchema: getQurlOutputSchema,
     annotations: {

--- a/src/tools/list-qurl-sessions.ts
+++ b/src/tools/list-qurl-sessions.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import type { IQURLClient } from "../client.js";
+import { resourceOnlyIdSchema, toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
+import { listQurlSessionsOutputSchema } from "./output-schemas.js";
+
+export const listQurlSessionsSchema = z.object({
+  resource_id: resourceOnlyIdSchema("list active sessions for"),
+});
+
+export function listQurlSessionsTool(client: IQURLClient) {
+  return {
+    name: "list_qurl_sessions",
+    title: "List qURL Sessions",
+    description:
+      "List active access sessions for a qURL resource. " +
+      "Use this to inspect who currently has live access before rotating, revoking, or terminating sessions. " +
+      "Use `terminate_qurl_sessions` when active sessions should be ended, and use `get_qurl` when you need token/resource metadata instead of active session state. " +
+      "**Behavior:** read-only and idempotent. Empty `data[]` means no active sessions for the resource.",
+    inputSchema: listQurlSessionsSchema,
+    outputSchema: listQurlSessionsOutputSchema,
+    annotations: {
+      title: "List qURL Sessions",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    handler: withMissingApiKeyHandler(async (input: z.infer<typeof listQurlSessionsSchema>) => {
+      const result = await client.listResourceSessions(input.resource_id);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+        structuredContent: toStructuredContent(result),
+      };
+    }),
+  };
+}

--- a/src/tools/list-qurls.ts
+++ b/src/tools/list-qurls.ts
@@ -21,10 +21,26 @@ export const listQurlsSchema = z.object({
       "Filter by status (comma-separated, e.g. 'active,revoked'). " +
         "Defaults to 'active' when omitted; pass 'revoked' or 'active,revoked' to override.",
     ),
-  created_after: z.string().datetime().optional().describe("Filter: created after this date (RFC 3339)"),
-  created_before: z.string().datetime().optional().describe("Filter: created before this date (RFC 3339)"),
-  expires_before: z.string().datetime().optional().describe("Filter: expires before this date (RFC 3339)"),
-  expires_after: z.string().datetime().optional().describe("Filter: expires after this date (RFC 3339)"),
+  created_after: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("Filter: created after this date (RFC 3339)"),
+  created_before: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("Filter: created before this date (RFC 3339)"),
+  expires_before: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("Filter: expires before this date (RFC 3339)"),
+  expires_after: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("Filter: expires after this date (RFC 3339)"),
   sort: z
     .string()
     .regex(
@@ -37,11 +53,7 @@ export const listQurlsSchema = z.object({
         "Valid fields: created_at, expires_at. Valid directions: asc, desc (default desc). " +
         "Example: 'created_at:desc'.",
     ),
-  q: z
-    .string()
-    .min(1)
-    .optional()
-    .describe("Search query (searches description and target_url)"),
+  q: z.string().min(1).optional().describe("Search query (searches description and target_url)"),
 });
 
 export function listQurlsTool(client: IQURLClient) {

--- a/src/tools/mint-link.ts
+++ b/src/tools/mint-link.ts
@@ -20,8 +20,14 @@ export const mintLinkBaseSchema = z.object({
     .string()
     .min(1)
     .optional()
-    .describe('Relative duration until expiration (e.g., "5m", "24h", "7d"). Mutually exclusive with expires_at'),
-  expires_at: z.string().datetime().optional().describe("Absolute expiration timestamp (RFC 3339). Mutually exclusive with expires_in"),
+    .describe(
+      'Relative duration until expiration (e.g., "5m", "24h", "7d"). Mutually exclusive with expires_at',
+    ),
+  expires_at: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("Absolute expiration timestamp (RFC 3339). Mutually exclusive with expires_in"),
   one_time_use: z.boolean().optional().describe("Whether this link can only be used once"),
   max_sessions: z
     .number()
@@ -29,12 +35,15 @@ export const mintLinkBaseSchema = z.object({
     .min(0)
     .max(1000)
     .optional()
-    .describe("Maximum concurrent sessions (0 = unlimited, max 1000)"),
+    .describe("Maximum concurrent sessions for this qURL token (0 = unlimited, max 1000)"),
   session_duration: z
     .string()
     .min(1)
     .optional()
-    .describe('How long access lasts after clicking (e.g., "1h")'),
+    .describe(
+      'How long access lasts after clicking (e.g., "1h"). ' +
+        "Rejected if it exceeds the parent resource's session-duration cap.",
+    ),
   access_policy: accessPolicySchema.optional().describe("Access control policy for this link"),
 });
 
@@ -48,13 +57,14 @@ export function mintLinkTool(client: IQURLClient) {
     name: "mint_link",
     title: "Mint Access Link",
     description:
-      "Mint a fresh single-use access link for an existing qURL resource — same one-shot semantics as `create_qurl.qurl_link`. " +
+      "Mint a fresh access link for an existing qURL resource — same one-shot display semantics as `create_qurl.qurl_link`. " +
       "Use this to issue additional access links to a resource without creating a brand-new qURL (e.g. a second recipient, a replacement after the original was lost). " +
       "Use `create_qurl` instead when you want a brand-new resource with its own target_url and policy. " +
       "Use `update_qurl` when you only want to change expiration/tags/description on the existing resource. " +
       "Accepts both `r_` and `q_` IDs. " +
       "**Constraints:** `expires_in` and `expires_at` are mutually exclusive (handler returns an `isError: true` content block before any API call if both are set). " +
-      "**Output:** the new `qurl_link` is shown ONCE — no subsequent call returns it. Save it immediately.",
+      "If neither expiry field is specified, the API defaults to 24 hours from now. " +
+      "**Output:** the new `qurl_link` is shown ONCE — no subsequent call returns it. Capture `qurl_id` if you need to correlate future access events or update this specific token.",
     inputSchema: mintLinkBaseSchema,
     outputSchema: mintLinkOutputSchema,
     annotations: {
@@ -68,10 +78,7 @@ export function mintLinkTool(client: IQURLClient) {
       const parsed = mintLinkSchema.safeParse(raw);
       if (!parsed.success) return zodErrorToToolResult(parsed.error);
       const { resource_id, ...body } = parsed.data;
-      // When only resource_id is provided, forward undefined so the client
-      // sends no body (and no Content-Type header) rather than an empty {}.
-      const hasBody = Object.keys(body).length > 0;
-      const result = await client.mintLink(resource_id, hasBody ? body : undefined);
+      const result = await client.mintLink(resource_id, body);
       return {
         content: [
           {

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -54,14 +54,20 @@ export const accessTokenOutputSchema = z
       .describe(
         "Per-token status (wider than resource status — tokens may be consumed/expired independently)",
       ),
-    one_time_use: z.boolean(),
-    max_sessions: z.number(),
-    session_duration: z.number().describe("Seconds of access granted after a successful resolve"),
-    use_count: z.number(),
+    // QurlSummary in api-spec/qurls.yaml intentionally has no `required`
+    // list, so these server-owned details are optional even though most
+    // responses include them.
+    one_time_use: z.boolean().optional(),
+    max_sessions: z.number().optional(),
+    session_duration: z
+      .number()
+      .optional()
+      .describe("Seconds of access granted after a successful resolve"),
+    use_count: z.number().optional(),
     qurl_site: z.string().optional(),
     access_policy: accessPolicy.optional(),
-    created_at: z.string(),
-    expires_at: z.string(),
+    created_at: z.string().optional(),
+    expires_at: z.string().optional(),
   })
   .describe("Single access token belonging to a qURL resource");
 

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -41,7 +41,7 @@ const accessPolicy = z
   })
   .describe("Access control policy snapshot for this token");
 
-const accessTokenSchema = z
+export const accessTokenOutputSchema = z
   .object({
     qurl_id: z.string(),
     label: z.string().optional(),
@@ -51,7 +51,9 @@ const accessTokenSchema = z
     status: z
       .enum(["active", "consumed", "expired", "revoked", "unknown"])
       .catch("unknown")
-      .describe("Per-token status (wider than resource status — tokens may be consumed/expired independently)"),
+      .describe(
+        "Per-token status (wider than resource status — tokens may be consumed/expired independently)",
+      ),
     one_time_use: z.boolean(),
     max_sessions: z.number(),
     session_duration: z.number().describe("Seconds of access granted after a successful resolve"),
@@ -67,7 +69,10 @@ const accessTokenSchema = z
 export const qurlSchema = z.object({
   resource_id: z.string().describe("Stable resource identifier (r_ prefix)"),
   qurl_site: z.string().optional(),
-  target_url: z.string().describe("Underlying URL the qURL protects"),
+  target_url: z
+    .string()
+    .optional()
+    .describe("Underlying URL the qURL protects; omitted on connector-owned resources"),
   description: z.string().optional(),
   tags: z.array(z.string()).optional(),
   expires_at: z.string(),
@@ -87,6 +92,10 @@ export const qurlSchema = z.object({
   // raw-input value (not just the coerced output) to disambiguate.
   status: z.enum(["active", "revoked", "expired", "unknown"]).catch("unknown"),
   custom_domain: z.string().nullable().optional(),
+  slug: z
+    .string()
+    .optional()
+    .describe("Immutable per-owner resource identity, when one was supplied at create time"),
   preserve_host: z
     .boolean()
     .optional()
@@ -95,7 +104,7 @@ export const qurlSchema = z.object({
         "Only meaningful when custom_domain is set; defaults to false on the API side.",
     ),
   qurl_count: z.number().optional().describe("Number of access tokens minted for this resource"),
-  qurls: z.array(accessTokenSchema).optional(),
+  qurls: z.array(accessTokenOutputSchema).optional(),
 });
 
 /** Ephemeral create-time payload — note `qurl_link` is one-shot. */
@@ -104,10 +113,17 @@ export const createQurlOutputSchema = z.object({
   resource_id: z.string().describe("Stable resource identifier (r_ prefix)"),
   qurl_link: z
     .string()
-    .describe("Single-use access link — shown ONCE on creation, never returned again. Share immediately."),
+    .describe(
+      "One-shot display access link — shown ONCE on creation, never returned again. Share immediately.",
+    ),
+  branded_domain: z
+    .string()
+    .optional()
+    .describe("Bare branded hostname for anchor text when the resource has a usable custom domain"),
   qurl_site: z.string(),
   expires_at: z.string(),
   label: z.string().optional(),
+  type: z.string().optional().describe("Resource type echoed from the create request"),
 });
 
 export const getQurlOutputSchema = qurlSchema;
@@ -121,14 +137,17 @@ export const extendQurlOutputSchema = qurlSchema;
 export const listQurlsOutputSchema = z.object({
   data: z.array(qurlSchema),
   meta: z.object({
-    next_cursor: z.string().optional().describe("Pass to a subsequent list_qurls call to fetch the next page"),
+    next_cursor: z
+      .string()
+      .optional()
+      .describe("Pass to a subsequent list_qurls call to fetch the next page"),
     has_more: z.boolean().describe("True if more pages are available beyond this response"),
     page_size: z.number().optional(),
     request_id: z.string().optional(),
   }),
 });
 
-/** Resolve response: target_url + the access_grant that opens the firewall. */
+/** Resolve response: target_url + the access_grant that grants network access. */
 export const resolveQurlOutputSchema = z.object({
   target_url: z.string().describe("Underlying URL revealed by the resolve"),
   resource_id: z.string(),
@@ -136,17 +155,61 @@ export const resolveQurlOutputSchema = z.object({
     .object({
       expires_in: z
         .number()
-        .describe("Seconds the firewall will permit access from `src_ip` before re-resolution is required"),
+        .describe(
+          "Seconds the network grant permits access from `src_ip` before re-resolution is required",
+        ),
       granted_at: z.string(),
       src_ip: z.string().describe("Caller IP that the access grant is bound to"),
     })
-    .describe("Time-bound, IP-bound access grant — required for the qURL firewall to permit the next request"),
+    .describe("Time-bound, IP-bound network access grant"),
 });
 
 /** Mint response: a fresh `qurl_link` for an existing resource. One-shot, like create_qurl. */
 export const mintLinkOutputSchema = z.object({
-  qurl_link: z.string().describe("Newly minted single-use access link (one-shot, like create_qurl)"),
+  qurl_id: z.string().describe("Display-friendly qURL ID (q_ prefix) for the minted token"),
+  qurl_link: z
+    .string()
+    .describe("Newly minted access link with one-shot display semantics, like create_qurl"),
+  branded_domain: z
+    .string()
+    .optional()
+    .describe("Bare branded hostname for anchor text when the resource has a usable custom domain"),
   expires_at: z.string(),
+  type: z.string().optional().describe("Resource type echoed from the underlying resource"),
+});
+
+export const updateQurlTokenOutputSchema = accessTokenOutputSchema;
+
+export const revokeQurlTokenOutputSchema = z.object({
+  resource_id: z.string(),
+  qurl_id: z.string(),
+  revoked: z.literal(true),
+  message: z.string(),
+});
+
+export const listQurlSessionsOutputSchema = z.object({
+  data: z.array(
+    z.object({
+      session_id: z.string(),
+      qurl_id: z.string().optional(),
+      src_ip: z.string().optional(),
+      user_agent: z.string().optional(),
+      created_at: z.string().optional(),
+      last_seen_at: z.string().optional(),
+    }),
+  ),
+  meta: z
+    .object({
+      request_id: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const terminateQurlSessionsOutputSchema = z.object({
+  resource_id: z.string(),
+  session_id: z.string().optional(),
+  terminated: z.number(),
+  message: z.string(),
 });
 
 // Discriminated on `success` so the schema enforces the API's
@@ -157,7 +220,11 @@ const batchItemSuccessSchema = z.object({
   index: z.number().describe("Index of the corresponding item in the input `items` array"),
   success: z.literal(true),
   resource_id: z.string(),
-  qurl_link: z.string().describe("One-shot access link — shown ONCE on creation"),
+  qurl_link: z.string().describe("One-shot display access link — shown ONCE on creation"),
+  branded_domain: z
+    .string()
+    .optional()
+    .describe("Bare branded hostname for anchor text when the resource has a usable custom domain"),
   qurl_site: z.string(),
   expires_at: z.string(),
 });

--- a/src/tools/resolve-qurl.ts
+++ b/src/tools/resolve-qurl.ts
@@ -15,8 +15,8 @@ export function resolveQurlTool(client: IQURLClient) {
     name: "resolve_qurl",
     title: "Resolve qURL Access Token",
     description:
-      "Redeem a qURL access token (the `at_` prefix you pulled out of a `qurl_link`) to reveal the underlying URL and open a time-bound, IP-bound firewall grant. " +
-      "Use this when an agent has been handed an access token and needs to fetch the protected resource — after a successful resolve, requests from `access_grant.src_ip` will be permitted to the `target_url` for `access_grant.expires_in` seconds. " +
+      "Redeem a qURL access token (the `at_` prefix you pulled out of a `qurl_link`) to reveal the underlying URL and obtain a time-bound, IP-bound network access grant. " +
+      "Use this when an agent has been handed an access token and needs to fetch the protected resource — after a successful resolve, requests from `access_grant.src_ip` are permitted to the `target_url` for `access_grant.expires_in` seconds. " +
       "Use `get_qurl` instead when you have a resource ID (`r_`) or qURL display ID (`q_`) and want admin-side details rather than end-user redemption. " +
       "**Side-effects:** consumes one use on `one_time_use` tokens, decrements `max_sessions`, and may trip access policies (IP/geo/UA/AI-agent denylists). " +
       "**`idempotentHint: false`** because one-time-use tokens consume on each call; for non-one-time tokens within an active grant window, repeats are effectively no-ops, but the conservative annotation reflects worst-case behavior.",

--- a/src/tools/revoke-qurl-token.ts
+++ b/src/tools/revoke-qurl-token.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { IQURLClient } from "../client.js";
+import {
+  qurlDisplayIdSchema,
+  resourceOnlyIdSchema,
+  toStructuredContent,
+  withMissingApiKeyHandler,
+} from "./_shared.js";
+import { revokeQurlTokenOutputSchema } from "./output-schemas.js";
+
+export const revokeQurlTokenSchema = z.object({
+  resource_id: resourceOnlyIdSchema("revoke a specific qURL token from"),
+  qurl_id: qurlDisplayIdSchema("revoke"),
+});
+
+export function revokeQurlTokenTool(client: IQURLClient) {
+  return {
+    name: "revoke_qurl_token",
+    title: "Revoke qURL Token",
+    description:
+      "Revoke one qURL token under a resource without revoking the whole resource. " +
+      "Use this when a single recipient/link should stop working but sibling qURLs on the same `resource_id` must remain active. " +
+      "Use `delete_qurl` instead when you want to revoke the resource and every token under it. " +
+      "**Constraints:** requires the parent `resource_id` (`r_…`) and the token display ID (`q_…`). Re-revoking an inactive token returns an API error rather than being treated as idempotent.",
+    inputSchema: revokeQurlTokenSchema,
+    outputSchema: revokeQurlTokenOutputSchema,
+    annotations: {
+      title: "Revoke qURL Token",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    handler: withMissingApiKeyHandler(async (input: z.infer<typeof revokeQurlTokenSchema>) => {
+      await client.revokeQurlToken(input.resource_id, input.qurl_id);
+      const payload = {
+        resource_id: input.resource_id,
+        qurl_id: input.qurl_id,
+        revoked: true as const,
+        message: `qURL token ${input.qurl_id} is revoked.`,
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: toStructuredContent(payload),
+      };
+    }),
+  };
+}

--- a/src/tools/terminate-qurl-sessions.ts
+++ b/src/tools/terminate-qurl-sessions.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { IQURLClient } from "../client.js";
+import { type IQURLClient, QURLAPIError } from "../client.js";
 import { resourceOnlyIdSchema, toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
 import { terminateQurlSessionsOutputSchema } from "./output-schemas.js";
 
@@ -54,7 +54,11 @@ export function terminateQurlSessionsTool(client: IQURLClient) {
         const result = await client.terminateAllResourceSessions(input.resource_id);
         const terminated = result.data?.terminated;
         if (typeof terminated !== "number") {
-          throw new Error("qURL API returned an invalid session termination response.");
+          throw new QURLAPIError(
+            502,
+            "invalid_response",
+            "qURL API returned an invalid session termination response.",
+          );
         }
 
         const payload = {

--- a/src/tools/terminate-qurl-sessions.ts
+++ b/src/tools/terminate-qurl-sessions.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import type { IQURLClient } from "../client.js";
+import { resourceOnlyIdSchema, toStructuredContent, withMissingApiKeyHandler } from "./_shared.js";
+import { terminateQurlSessionsOutputSchema } from "./output-schemas.js";
+
+export const terminateQurlSessionsSchema = z.object({
+  resource_id: resourceOnlyIdSchema("terminate sessions for"),
+  session_id: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Specific session ID to terminate. Omit to terminate all active sessions for the resource.",
+    ),
+});
+
+export function terminateQurlSessionsTool(client: IQURLClient) {
+  return {
+    name: "terminate_qurl_sessions",
+    title: "Terminate qURL Sessions",
+    description:
+      "Terminate active access sessions for a qURL resource. " +
+      "Use this after shortening access, rotating a link, or responding to a suspected leak when already-open sessions should end immediately. " +
+      "Pass `session_id` to terminate one active session; omit it to terminate all active sessions for the resource. " +
+      "Use `list_qurl_sessions` first when you need to inspect current sessions before taking action. " +
+      "**Side-effects:** existing access sessions are closed; qURL tokens themselves are not revoked.",
+    inputSchema: terminateQurlSessionsSchema,
+    outputSchema: terminateQurlSessionsOutputSchema,
+    annotations: {
+      title: "Terminate qURL Sessions",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    handler: withMissingApiKeyHandler(
+      async (input: z.infer<typeof terminateQurlSessionsSchema>) => {
+        if (input.session_id) {
+          await client.terminateResourceSession(input.resource_id, input.session_id);
+          const payload = {
+            resource_id: input.resource_id,
+            session_id: input.session_id,
+            terminated: 1,
+            message: `qURL session ${input.session_id} is terminated.`,
+          };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+            structuredContent: toStructuredContent(payload),
+          };
+        }
+
+        const result = await client.terminateAllResourceSessions(input.resource_id);
+        const payload = {
+          resource_id: input.resource_id,
+          terminated: result.data.terminated,
+          message: `Terminated ${result.data.terminated} qURL session(s).`,
+        };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+          structuredContent: toStructuredContent(payload),
+        };
+      },
+    ),
+  };
+}

--- a/src/tools/terminate-qurl-sessions.ts
+++ b/src/tools/terminate-qurl-sessions.ts
@@ -40,6 +40,8 @@ export function terminateQurlSessionsTool(client: IQURLClient) {
           const payload = {
             resource_id: input.resource_id,
             session_id: input.session_id,
+            // The API returns 204 for a single session delete, so the tool
+            // synthesizes the count from the successful operation.
             terminated: 1,
             message: `qURL session ${input.session_id} is terminated.`,
           };
@@ -50,10 +52,15 @@ export function terminateQurlSessionsTool(client: IQURLClient) {
         }
 
         const result = await client.terminateAllResourceSessions(input.resource_id);
+        const terminated = result.data?.terminated;
+        if (typeof terminated !== "number") {
+          throw new Error("qURL API returned an invalid session termination response.");
+        }
+
         const payload = {
           resource_id: input.resource_id,
-          terminated: result.data.terminated,
-          message: `Terminated ${result.data.terminated} qURL session(s).`,
+          terminated,
+          message: `Terminated ${terminated} qURL session(s).`,
         };
         return {
           content: [{ type: "text" as const, text: JSON.stringify(payload) }],

--- a/src/tools/update-qurl-token.ts
+++ b/src/tools/update-qurl-token.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import type { IQURLClient } from "../client.js";
+import { accessPolicySchema } from "./create-qurl.js";
+import {
+  qurlDisplayIdSchema,
+  resourceOnlyIdSchema,
+  toStructuredContent,
+  withMissingApiKeyHandler,
+  zodErrorToToolResult,
+} from "./_shared.js";
+import { updateQurlTokenOutputSchema } from "./output-schemas.js";
+
+export const updateQurlTokenBaseSchema = z.object({
+  resource_id: resourceOnlyIdSchema("update a specific qURL token under"),
+  qurl_id: qurlDisplayIdSchema("update"),
+  extend_by: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Duration to extend this token by (e.g., "24h", "7d"). Mutually exclusive with expires_at.',
+    ),
+  expires_at: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("Absolute token expiration timestamp (RFC 3339). Mutually exclusive with extend_by."),
+  label: z.string().max(500).optional().describe("Human-readable label for this token"),
+  access_policy: accessPolicySchema.optional().describe("Replace the access policy for this token"),
+  max_sessions: z
+    .number()
+    .int()
+    .min(0)
+    .max(1000)
+    .optional()
+    .describe("Maximum concurrent sessions for this token (0 = unlimited, max 1000)"),
+  session_duration: z
+    .string()
+    .optional()
+    .describe(
+      'How long access lasts after clicking (e.g., "1h"). Empty string applies the parent resource cap when one is set.',
+    ),
+});
+
+export const updateQurlTokenSchema = updateQurlTokenBaseSchema
+  .refine((data) => !(data.extend_by && data.expires_at), {
+    message: "Provide either extend_by or expires_at, not both",
+  })
+  .refine(
+    (data) =>
+      data.extend_by !== undefined ||
+      data.expires_at !== undefined ||
+      data.label !== undefined ||
+      data.access_policy !== undefined ||
+      data.max_sessions !== undefined ||
+      data.session_duration !== undefined,
+    {
+      message:
+        "At least one update field (extend_by, expires_at, label, access_policy, max_sessions, or session_duration) is required",
+    },
+  );
+
+export function updateQurlTokenTool(client: IQURLClient) {
+  return {
+    name: "update_qurl_token",
+    title: "Update qURL Token",
+    description:
+      "Update one qURL token under a resource: expiration, label, access policy, max sessions, or session duration. " +
+      "Use this when you need to change a specific `q_…` token without changing sibling tokens or resource-level metadata. " +
+      "Use `update_qurl` instead for resource-level description/tags/custom-domain changes, and use `revoke_qurl_token` when the token should stop working entirely. " +
+      "**Constraints:** `extend_by` and `expires_at` are mutually exclusive; at least one token update field must be set. " +
+      "Returns the updated token summary.",
+    inputSchema: updateQurlTokenBaseSchema,
+    outputSchema: updateQurlTokenOutputSchema,
+    annotations: {
+      title: "Update qURL Token",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    handler: withMissingApiKeyHandler(async (raw: z.infer<typeof updateQurlTokenBaseSchema>) => {
+      const parsed = updateQurlTokenSchema.safeParse(raw);
+      if (!parsed.success) return zodErrorToToolResult(parsed.error);
+      const { resource_id, qurl_id, ...body } = parsed.data;
+      const result = await client.updateQurlToken(resource_id, qurl_id, body);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result.data) }],
+        structuredContent: toStructuredContent(result.data),
+      };
+    }),
+  };
+}

--- a/src/tools/update-qurl.ts
+++ b/src/tools/update-qurl.ts
@@ -22,8 +22,16 @@ const tagSchema = z
 
 export const updateQurlBaseSchema = z.object({
   resource_id: resourceIdSchema("update"),
-  extend_by: z.string().min(1).optional().describe('Duration to extend by (e.g., "24h", "7d"). Mutually exclusive with expires_at.'),
-  expires_at: z.string().datetime().optional().describe("Absolute expiration timestamp (RFC 3339). Mutually exclusive with extend_by."),
+  extend_by: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Duration to extend by (e.g., "24h", "7d"). Mutually exclusive with expires_at.'),
+  expires_at: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("Absolute expiration timestamp (RFC 3339). Mutually exclusive with extend_by."),
   tags: z
     .array(tagSchema)
     .max(10)
@@ -82,7 +90,7 @@ export function updateQurlTool(client: IQURLClient) {
       "Update a qURL's expiration, tags, description, custom domain, or proxy host-header behavior. The richer alternative to `extend_qurl` — use `update_qurl` whenever you need anything beyond a relative time push. " +
       "Accepts both `r_` and `q_` IDs (q_ is auto-resolved). " +
       "**Constraints:** `extend_by` and `expires_at` are mutually exclusive; at least one update field (`extend_by`, `expires_at`, `tags`, `description`, `custom_domain`, `preserve_host`) must be set. " +
-      "**Clearing fields:** pass `description: \"\"`, `tags: []`, or `custom_domain: \"\"` to clear those fields explicitly. " +
+      '**Clearing fields:** pass `description: ""`, `tags: []`, or `custom_domain: ""` to clear those fields explicitly. ' +
       "Use `extend_qurl` when the only change is a relative time push. " +
       "Use `delete_qurl` when you want to revoke entirely. " +
       "**Errors:** if the input fails schema refinements (both extend_by + expires_at, or no fields set), the handler returns an `isError: true` content block before any API call. Other API errors throw with the API's `code`/`statusCode`. " +

--- a/src/tools/update-qurl.ts
+++ b/src/tools/update-qurl.ts
@@ -116,6 +116,9 @@ export function updateQurlTool(client: IQURLClient) {
       const parsed = updateQurlSchema.safeParse(raw);
       if (!parsed.success) return zodErrorToToolResult(parsed.error);
       const { resource_id } = parsed.data;
+      // Both API endpoints accept tags/description; keep qURL-only updates
+      // on /v1/qurls/{id} for q_ auto-resolution, and move custom-domain /
+      // host-header changes to /v1/resources/{id} per UpdateResourceRequest.
       const result = hasResourceEndpointUpdate(parsed.data)
         ? await client.updateResource(resource_id, buildResourceUpdateBody(parsed.data))
         : await client.updateQURL(resource_id, buildQurlUpdateBody(parsed.data));

--- a/src/tools/update-qurl.ts
+++ b/src/tools/update-qurl.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { IQURLClient } from "../client.js";
+import type { IQURLClient, UpdateQURLInput, UpdateResourceInput } from "../client.js";
 import {
   resourceIdSchema,
   toStructuredContent,
@@ -63,6 +63,13 @@ export const updateQurlSchema = updateQurlBaseSchema
   .refine((data) => !(data.extend_by && data.expires_at), {
     message: "Provide either extend_by or expires_at, not both",
   })
+  .refine((data) => !(hasExpirationUpdate(data) && hasResourceEndpointUpdate(data)), {
+    message:
+      "custom_domain and preserve_host use the resource endpoint and cannot be combined with extend_by or expires_at in one update",
+  })
+  .refine((data) => !(hasResourceEndpointUpdate(data) && data.resource_id.startsWith("q_")), {
+    message: "custom_domain and preserve_host updates require an r_ resource ID",
+  })
   .refine(
     // Use `!== undefined` rather than truthy checks so the API's "clear"
     // semantics work: the spec documents `description: ""` and `tags: []`
@@ -88,8 +95,8 @@ export function updateQurlTool(client: IQURLClient) {
     title: "Update qURL",
     description:
       "Update a qURL's expiration, tags, description, custom domain, or proxy host-header behavior. The richer alternative to `extend_qurl` — use `update_qurl` whenever you need anything beyond a relative time push. " +
-      "Accepts both `r_` and `q_` IDs (q_ is auto-resolved). " +
-      "**Constraints:** `extend_by` and `expires_at` are mutually exclusive; at least one update field (`extend_by`, `expires_at`, `tags`, `description`, `custom_domain`, `preserve_host`) must be set. " +
+      "Accepts both `r_` and `q_` IDs for expiration, tags, and description updates (q_ is auto-resolved); custom domain and preserve_host updates require an `r_` resource ID because the qURL API now serves them from `PATCH /v1/resources/{id}`. " +
+      "**Constraints:** `extend_by` and `expires_at` are mutually exclusive; `custom_domain`/`preserve_host` cannot be combined with expiration changes in one call; at least one update field (`extend_by`, `expires_at`, `tags`, `description`, `custom_domain`, `preserve_host`) must be set. " +
       '**Clearing fields:** pass `description: ""`, `tags: []`, or `custom_domain: ""` to clear those fields explicitly. ' +
       "Use `extend_qurl` when the only change is a relative time push. " +
       "Use `delete_qurl` when you want to revoke entirely. " +
@@ -108,8 +115,10 @@ export function updateQurlTool(client: IQURLClient) {
     handler: withMissingApiKeyHandler(async (raw: z.infer<typeof updateQurlBaseSchema>) => {
       const parsed = updateQurlSchema.safeParse(raw);
       if (!parsed.success) return zodErrorToToolResult(parsed.error);
-      const { resource_id, ...body } = parsed.data;
-      const result = await client.updateQURL(resource_id, body);
+      const { resource_id } = parsed.data;
+      const result = hasResourceEndpointUpdate(parsed.data)
+        ? await client.updateResource(resource_id, buildResourceUpdateBody(parsed.data))
+        : await client.updateQURL(resource_id, buildQurlUpdateBody(parsed.data));
       return {
         content: [
           {
@@ -121,4 +130,32 @@ export function updateQurlTool(client: IQURLClient) {
       };
     }),
   };
+}
+
+type ParsedUpdateQurl = z.infer<typeof updateQurlBaseSchema>;
+
+function hasExpirationUpdate(data: ParsedUpdateQurl) {
+  return data.extend_by !== undefined || data.expires_at !== undefined;
+}
+
+function hasResourceEndpointUpdate(data: ParsedUpdateQurl) {
+  return data.custom_domain !== undefined || data.preserve_host !== undefined;
+}
+
+function buildQurlUpdateBody(data: ParsedUpdateQurl): UpdateQURLInput {
+  const body: UpdateQURLInput = {};
+  if (data.extend_by !== undefined) body.extend_by = data.extend_by;
+  if (data.expires_at !== undefined) body.expires_at = data.expires_at;
+  if (data.tags !== undefined) body.tags = data.tags;
+  if (data.description !== undefined) body.description = data.description;
+  return body;
+}
+
+function buildResourceUpdateBody(data: ParsedUpdateQurl): UpdateResourceInput {
+  const body: UpdateResourceInput = {};
+  if (data.tags !== undefined) body.tags = data.tags;
+  if (data.description !== undefined) body.description = data.description;
+  if (data.custom_domain !== undefined) body.custom_domain = data.custom_domain;
+  if (data.preserve_host !== undefined) body.preserve_host = data.preserve_host;
+  return body;
 }


### PR DESCRIPTION
## Summary
- Sync api-spec/qurls.yaml exactly from qurl-service origin/main (330cb65f487d8d0cb2b1c5448d2e0ab35d4341c0).
- Update existing qURL tools for the latest wire contract: network-access wording, exact ID schemas, required empty JSON mint body, branded-domain/type/qurl_id response fields, optional redacted target_url, tombstone metadata, and resource-grouping semantics.
- Add MCP tools for the new link-management surfaces: revoke_qurl_token, update_qurl_token, list_qurl_sessions, and terminate_qurl_sessions.
- Refresh README and contract-drift tests around schemas, TDQS metadata, wrapper coverage, and client route behavior.

## Business relevance
Keeping qurl-mcp aligned with qurl-service prevents AI agents from planning against stale API shapes, especially around token-level revocation/session control and branded-domain/custom-domain display. This lowers support risk for customers using MCP clients to create, rotate, inspect, and shut down qURL access.

## Validation
- npm test
- npm run build
- npm run lint
- npm run format:check
- git diff --check
- Verified api-spec/qurls.yaml byte-for-byte matches qurl-service origin/main:api/openapi.yaml at 330cb65f487d8d0cb2b1c5448d2e0ab35d4341c0