### PR TITLE
ci: use default docker builder for image check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      # This job builds one local image and immediately runs it. The default
+      # Docker builder is enough and avoids bootstrapping a separate BuildKit
+      # container before CI even reaches this repository's Dockerfile.
       - name: Build image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-# node:22-alpine pinned by digest (Renovate/Dependabot will keep it current).
+# node:26-alpine pinned by digest (Renovate/Dependabot will keep it current).
 # Floating tags would shift between builds and reopen a supply-chain seam the
 # rest of this workflow's SHA-pinned actions are designed to close.
 FROM node:26-alpine@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31a151f3f7eea3a2a8541 AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-# node:26-alpine pinned by digest (Renovate/Dependabot will keep it current).
+# Base image pinned by digest (Renovate/Dependabot will keep it current).
 # Floating tags would shift between builds and reopen a supply-chain seam the
 # rest of this workflow's SHA-pinned actions are designed to close.
 FROM node:26-alpine@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31a151f3f7eea3a2a8541 AS build


### PR DESCRIPTION
## Summary

Remove the explicit Docker Buildx setup step from the Docker CI job so the local image check uses Docker Engine's default builder instead of bootstrapping a separate BuildKit container from Docker Hub. Also simplify the Dockerfile base-image comment so the `FROM` lines remain the only image-tag source of truth.

## Business Relevance

The failed main build stopped before the repository image build because Buildx could not pull the helper BuildKit image. Keeping this single-image local verification on the default Docker builder reduces registry/bootstrap flake exposure and keeps the Docker CI gate focused on qurl-mcp image health.

## Changes

- Remove `docker/setup-buildx-action` from the Docker job.
- Document why the default Docker builder is sufficient for this build-and-run check.
- Update and simplify the Dockerfile base-image comment so it no longer duplicates the Node tag from the `FROM` line.
- Tracked the optional Dockerfile `ARG NODE_IMAGE` hoist evaluation in #150 because Dependabot Docker update compatibility needs verification first.

## Test Plan

- [x] `npm ci`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (25 files, 460 tests)
- [x] `docker buildx build --load -t qurl-mcp:ci .`
- [x] MCP introspection probe against `qurl-mcp:ci`
- [x] Workflow YAML parse
- [x] `git diff --check`
- [ ] Manually tested with MCP client (not applicable; Docker introspection probe covers the CI container path)

## Related Issues

Relates to https://github.com/layervai/qurl-mcp/actions/runs/27069473730
Follow-up: #150