### PR TITLE
docs: drop "firewall" terminology in CLAUDE.md tools table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ npm run format
 | Tool | Scope Required | Description |
 |------|---------------|-------------|
 | `create_qurl` | `qurl:write` | Create a protected link |
-| `resolve_qurl` | `qurl:resolve` | Resolve token + open firewall |
+| `resolve_qurl` | `qurl:resolve` | Resolve token + grant network access |
 | `list_qurls` | `qurl:read` | List qURLs with filtering |
 | `get_qurl` | `qurl:read` | Get qURL details |
 | `delete_qurl` | `qurl:write` | Revoke a qURL |


### PR DESCRIPTION
## What

`CLAUDE.md`'s Tools table described `resolve_qurl` as **"Resolve token + open firewall"**, even though the README's tools table already says **"grant network access"** and the registered tool descriptions use that wording. Aligns the one stale reference.

LayerV is not a firewall company; qURL's mechanism is described as granting network access via the NHP knock. Part of a cross-repo qURL terminology pass (integrations repo, Python SDK #74, TypeScript SDK #118).

`grep -i firewall` now returns nothing in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)