### PR TITLE
docs: remove sandbox servers from the API spec

### DIFF
--- a/api-spec/qurls.yaml
+++ b/api-spec/qurls.yaml
@@ -94,8 +94,6 @@ info:
 servers:
   - url: https://api.layerv.ai
     description: Production
-  - url: https://api.layerv.xyz
-    description: Sandbox
 
 security:
   - bearerAuth: []
@@ -248,8 +246,6 @@ paths:
       servers:
         - url: https://bootstrap.layerv.ai
           description: Production bootstrap endpoint
-        - url: https://bootstrap.layerv.xyz
-          description: Sandbox bootstrap endpoint
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Why

The sandbox environment is internal-only and must not appear in any public, customer-facing surface. `api-spec/qurls.yaml` is **customer-facing** — its header says it "drives the customer-facing API reference (Scalar)" and explicitly forbids leaking **internal hostnames**. It listed two sandbox servers:

- top-level `servers`: `https://api.layerv.xyz` (*Sandbox*)
- bootstrap op `servers`: `https://bootstrap.layerv.xyz` (*Sandbox bootstrap endpoint*)

Both removed; only the production hosts remain.

## Safety
- The snapshot is `.dockerignore`d and not loaded at runtime — it's a codegen/reference snapshot, so this is doc-only with no behavior change.
- `npm run build` (tsc), `npm run lint`, and `npm test` (460 passing) all green.
- `grep -i layerv.xyz` now returns nothing.

## ⚠️ Upstream root cause (needs a qurl-service change)

This snapshot mirrors the live spec at `https://api.layerv.ai/v1/openapi.yaml`, which is checked weekly for drift (`.github/workflows/api-spec-check.yml`). **The live upstream spec still exposes the sandbox servers** — and since it drives the production customer-facing Scalar reference, the sandbox is currently visible to customers there. Unless the upstream `qurl-service` openapi.yaml also drops the sandbox servers, the drift check will re-introduce them into this snapshot. Recommend fixing upstream in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)