### PR TITLE
feat(client): use the @layervai/qurl SDK instead of the hand-rolled client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ qurl-mcp/
 ├── src/
 │   ├── index.ts           # Entry point, env validation, stdio transport
 │   ├── server.ts          # MCP server factory, tool/resource/prompt registration
-│   ├── client.ts          # TypeScript qURL API client
+│   ├── client.ts          # Adapter over the @layervai/qurl SDK (IQURLClient + QURLAPIError)
 │   ├── tools/
 │   │   ├── _shared.ts       # resourceIdSchema, zodErrorToToolResult
 │   │   ├── create-qurl.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@layervai/qurl": "^0.2.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^4.4.3"
       },
@@ -253,6 +254,15 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@layervai/qurl": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@layervai/qurl/-/qurl-0.2.0.tgz",
+      "integrity": "sha512-+ldlWnnXPBQKAkGO/5v00FdK6bOvK2kMW7Cii1/BO4RG5Vu7SiBinvt37YcgmNJtkQY+bw3kw127q5o2Hij0CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/layervai/qurl-mcp"
   },
   "dependencies": {
+    "@layervai/qurl": "^0.2.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vitest": "^4.1.5"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist/"

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,977 +1,227 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { QURLClient, QURLAPIError } from "../client.js";
 
-function stubFetch(body: unknown, status = 200) {
-  const mock = vi.fn().mockResolvedValue({
-    ok: status >= 200 && status < 300,
-    status,
-    text: () => Promise.resolve(JSON.stringify(body)),
+// `client.ts` is now a thin adapter over the `@layervai/qurl` SDK. These tests
+// mock the SDK so we can assert the adapter's translation layer in isolation:
+// lazy/keyless construction, `{ data }` re-wrapping, the `access_tokens` →
+// `qurls` rename, the list/batch/session envelope reshaping, the method
+// renames, and the `QURLError` → `QURLAPIError` mapping. The HTTP/retry/parse
+// behavior the old hand-rolled client used to be tested for now lives in (and
+// is tested by) the SDK itself.
+
+const { sdk, SDKClientMock } = vi.hoisted(() => {
+  const sdk = {
+    create: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn(),
+    updateResource: vi.fn(),
+    extend: vi.fn(),
+    resolve: vi.fn(),
+    getQuota: vi.fn(),
+    mintLink: vi.fn(),
+    batchCreate: vi.fn(),
+    revokeResourceQurl: vi.fn(),
+    updateResourceQurl: vi.fn(),
+    listResourceSessions: vi.fn(),
+    terminateResourceSession: vi.fn(),
+    terminateAllResourceSessions: vi.fn(),
+  };
+  // The SDK constructor returns our shared stub instance. Must be a regular
+  // function (not an arrow) so the adapter's `new SDKQURLClient(...)` works —
+  // a constructor that returns an object makes `new` yield that object.
+  const SDKClientMock = vi.fn(function () {
+    return sdk;
   });
-  vi.stubGlobal("fetch", mock);
-  return mock;
-}
+  return { sdk, SDKClientMock };
+});
 
-describe("QURLClient", () => {
-  let client: QURLClient;
+vi.mock("@layervai/qurl", async (importOriginal) => {
+  // Keep the real error classes (so NotFoundError etc. behave like the SDK),
+  // swap only the client constructor for our stub.
+  const actual = await importOriginal<typeof import("@layervai/qurl")>();
+  return { ...actual, QURLClient: SDKClientMock };
+});
 
-  beforeEach(() => {
-    client = new QURLClient({
-      apiKey: "test-key",
-      baseURL: "https://api.test.com",
-    });
-  });
+import { QURLClient, QURLAPIError, MISSING_API_KEY_MESSAGE } from "../client.js";
+import { NotFoundError, AuthorizationError } from "@layervai/qurl";
 
-  describe("constructor", () => {
-    it("stores apiKey and baseURL", async () => {
-      const customClient = new QURLClient({
-        apiKey: "custom-key",
-        baseURL: "https://api.example.com",
-      });
-      const mock = stubFetch({ data: {} });
+const newClient = (apiKey = "lv_live_key", baseURL = "https://api.test.layerv.ai") =>
+  new QURLClient({ apiKey, baseURL });
 
-      await customClient.getQuota();
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.example.com/v1/quota",
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: "Bearer custom-key",
-          }),
-        }),
-      );
+describe("QURLClient adapter", () => {
+  describe("keyless boot", () => {
+    it("does not construct the SDK when no key is configured", () => {
+      expect(() => newClient("")).not.toThrow();
+      expect(SDKClientMock).not.toHaveBeenCalled();
     });
 
-    it("strips trailing slash from baseURL", async () => {
-      const customClient = new QURLClient({
-        apiKey: "test-key",
-        baseURL: "https://api.example.com/",
-      });
-      const mock = stubFetch({ data: {} });
+    it("defers the missing-key error to the first API call (status 0, code missing_api_key)", async () => {
+      // Whitespace-only keys take the same path as truly unset.
+      const client = newClient("   ");
+      const err = (await client.getQURL("r_x").catch((e: unknown) => e)) as QURLAPIError;
 
-      await customClient.getQuota();
-
-      expect(mock).toHaveBeenCalledWith("https://api.example.com/v1/quota", expect.any(Object));
-    });
-  });
-
-  describe("missing apiKey guard", () => {
-    // Locks in the contract: when QURL_API_KEY is unset (introspection-only
-    // mode), every API call must throw a typed missing_api_key error before
-    // any network request is issued. Removing this guard would silently fall
-    // through to a 401 from the server, masking the configuration problem.
-    //
-    // Parameterized over both empty and whitespace-only keys so the
-    // constructor's `.trim()` (the sole gate against the whitespace case)
-    // is exercised against the entire client surface, not just
-    // a single representative method.
-    const missingKeyCases: Array<[string, string]> = [
-      ["empty", ""],
-      ["whitespace-only", "   \t\n  "],
-    ];
-
-    for (const [label, apiKey] of missingKeyCases) {
-      it(`throws missing_api_key for every API method when apiKey is ${label}, without issuing a network request`, async () => {
-        const noKeyClient = new QURLClient({
-          apiKey,
-          baseURL: "https://api.test.com",
-        });
-        const mock = vi.fn();
-        vi.stubGlobal("fetch", mock);
-
-        const calls: Array<() => Promise<unknown>> = [
-          () => noKeyClient.createQURL({ target_url: "https://example.com" }),
-          () => noKeyClient.getQURL("r_x"),
-          () => noKeyClient.listQURLs(),
-          () => noKeyClient.deleteQURL("r_x"),
-          () => noKeyClient.updateQURL("r_x", { extend_by: "1h" }),
-          () => noKeyClient.updateResource("r_x", { custom_domain: "app.example.com" }),
-          () => noKeyClient.extendQURL("r_x", { extend_by: "1h" }),
-          () => noKeyClient.resolveQURL({ access_token: "at_x" }),
-          () => noKeyClient.getQuota(),
-          () => noKeyClient.mintLink("r_x"),
-          () => noKeyClient.batchCreate({ items: [{ target_url: "https://example.com" }] }),
-          () => noKeyClient.revokeQurlToken("r_x", "q_x"),
-          () => noKeyClient.updateQurlToken("r_x", "q_x", { extend_by: "1h" }),
-          () => noKeyClient.listResourceSessions("r_x"),
-          () => noKeyClient.terminateResourceSession("r_x", "sess_x"),
-          () => noKeyClient.terminateAllResourceSessions("r_x"),
-        ];
-
-        for (const call of calls) {
-          // toMatchObject rather than toBeInstanceOf catches a regression
-          // where a method routes around `request()` and throws a different
-          // QURLAPIError for an unrelated reason — e.g. extendQURL already
-          // delegates to updateQURL today; a sibling that doesn't would slip
-          // a looser instanceof check.
-          await expect(call()).rejects.toMatchObject({
-            name: "QURLAPIError",
-            code: "missing_api_key",
-            statusCode: 0,
-          });
-        }
-        // Intent of this guard is "no network until the key is set" — assert
-        // it directly rather than just trusting that any QURLAPIError suffices.
-        expect(mock).not.toHaveBeenCalled();
-      });
-    }
-  });
-
-  describe("request headers", () => {
-    it("sends Authorization bearer header on all requests", async () => {
-      const mock = stubFetch({ data: {} });
-
-      await client.getQuota();
-
-      expect(mock).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: "Bearer test-key",
-          }),
-        }),
-      );
-    });
-
-    it("sends Content-Type only when request has a body", async () => {
-      const mock = stubFetch({ data: {} });
-
-      await client.createQURL({ target_url: "https://example.com" });
-
-      expect(mock).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            "Content-Type": "application/json",
-          }),
-        }),
-      );
-    });
-
-    it("omits Content-Type on GET requests", async () => {
-      const mock = stubFetch({ data: {} });
-
-      await client.getQuota();
-
-      const headers = (mock.mock.calls[0][1] as { headers: Record<string, string> }).headers;
-      expect(headers).not.toHaveProperty("Content-Type");
-    });
-  });
-
-  describe("error handling", () => {
-    it("throws QURLAPIError on 4xx response with RFC 7807 format", async () => {
-      stubFetch(
-        {
-          error: {
-            type: "https://api.qurl.link/problems/not_found",
-            title: "Resource Not Found",
-            status: 404,
-            detail: "QURL not found",
-            instance: "/v1/qurls/r_nonexistent",
-            code: "not_found",
-          },
-          meta: { request_id: "req_abc123" },
-        },
-        404,
-      );
-
-      const err = (await client.getQURL("r_nonexistent").catch((e: unknown) => e)) as QURLAPIError;
       expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err.statusCode).toBe(404);
-      expect(err.code).toBe("not_found");
-      expect(err.message).toBe("QURL not found");
-      expect(err.type).toBe("https://api.qurl.link/problems/not_found");
-      expect(err.instance).toBe("/v1/qurls/r_nonexistent");
-      expect(err.requestId).toBe("req_abc123");
+      expect(err.code).toBe("missing_api_key");
+      expect(err.statusCode).toBe(0);
+      expect(err.message).toBe(MISSING_API_KEY_MESSAGE);
+      // The SDK (which throws on an empty key) is never constructed.
+      expect(SDKClientMock).not.toHaveBeenCalled();
     });
+  });
 
-    it("preserves tombstone metadata from 410 Gone responses", async () => {
-      stubFetch(
-        {
-          error: {
-            type: "https://api.qurl.link/problems/gone",
-            title: "Resource Gone",
-            status: 410,
-            detail: "Resource lifecycle closed",
-            instance: "/v1/resources/r_abc123def45",
-            code: "gone",
-          },
-          meta: {
-            request_id: "req_gone",
-            tombstone: {
-              tombstoned_at: "2026-06-01T00:00:00Z",
-              final_access_count: 42,
-            },
-          },
-        },
-        410,
-      );
+  describe("lazy SDK construction", () => {
+    it("constructs the SDK once, mapping baseURL → baseUrl and trimming the trailing slash", async () => {
+      sdk.get.mockResolvedValue({ resource_id: "r_x" });
+      const client = newClient("lv_live_key", "https://api.test.layerv.ai/");
 
-      const err = (await client.getQURL("r_abc123def45").catch((e: unknown) => e)) as QURLAPIError;
-      expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err.statusCode).toBe(410);
-      expect(err.requestId).toBe("req_gone");
-      expect(err.tombstone).toEqual({
-        tombstoned_at: "2026-06-01T00:00:00Z",
-        final_access_count: 42,
+      await client.getQURL("r_x");
+      await client.getQURL("r_y");
+
+      expect(SDKClientMock).toHaveBeenCalledTimes(1);
+      expect(SDKClientMock).toHaveBeenCalledWith({
+        apiKey: "lv_live_key",
+        baseUrl: "https://api.test.layerv.ai",
       });
     });
-
-    it("throws QURLAPIError on 5xx response", async () => {
-      stubFetch(
-        {
-          error: {
-            type: "https://api.qurl.link/problems/internal_error",
-            title: "Internal Error",
-            status: 500,
-            detail: "Server error",
-            code: "internal_error",
-          },
-        },
-        500,
-      );
-
-      const err = (await client.getQuota().catch((e: unknown) => e)) as QURLAPIError;
-      expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err.statusCode).toBe(500);
-      expect(err.code).toBe("internal_error");
-      expect(err.message).toBe("Server error");
-    });
-
-    it("falls back to error.message for legacy error format", async () => {
-      stubFetch({ error: { code: "not_found", message: "Resource not found" } }, 404);
-
-      const err = (await client.getQURL("r_nonexistent").catch((e: unknown) => e)) as QURLAPIError;
-      expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err.statusCode).toBe(404);
-      expect(err.code).toBe("not_found");
-      expect(err.message).toBe("Resource not found");
-      // RFC 7807 fields are not present in legacy format
-      expect(err.type).toBeUndefined();
-      expect(err.instance).toBeUndefined();
-      expect(err.requestId).toBeUndefined();
-    });
-
-    it("falls back to error.title when detail is missing", async () => {
-      stubFetch(
-        {
-          error: {
-            type: "https://api.qurl.link/problems/forbidden",
-            title: "Forbidden",
-            status: 403,
-            code: "forbidden",
-          },
-        },
-        403,
-      );
-
-      const err = (await client.getQuota().catch((e: unknown) => e)) as QURLAPIError;
-      expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err.message).toBe("Forbidden");
-      expect(err.type).toBe("https://api.qurl.link/problems/forbidden");
-    });
-
-    it("throws QURLAPIError with defaults when error body has no error field", async () => {
-      stubFetch({ some: "data" }, 403);
-
-      const err = await client.getQuota().catch((e: unknown) => e);
-      expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err).toMatchObject({
-        statusCode: 403,
-        code: "unknown",
-        message: "HTTP 403",
-      });
-    });
-
-    it("throws QURLAPIError on non-JSON response", async () => {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn().mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve("not json at all"),
-        }),
-      );
-
-      const err = await client.getQuota().catch((e: unknown) => e);
-      expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err).toMatchObject({
-        statusCode: 200,
-        code: "parse_error",
-      });
-    });
-
-    it("truncates long non-JSON response in error message", async () => {
-      const longText = "x".repeat(300);
-      vi.stubGlobal(
-        "fetch",
-        vi.fn().mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(longText),
-        }),
-      );
-
-      const err = (await client.getQuota().catch((e: unknown) => e)) as QURLAPIError;
-      expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err.message).toBe("Failed to parse response: " + "x".repeat(200));
-    });
-
-    it("handles empty 2xx response body (204 No Content)", async () => {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn().mockResolvedValue({
-          ok: true,
-          status: 204,
-          text: () => Promise.resolve(""),
-        }),
-      );
-
-      const result = await client.deleteQURL("r_abc");
-      expect(result).toBeUndefined();
-    });
-
-    it("throws on empty non-2xx response body", async () => {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn().mockResolvedValue({
-          ok: false,
-          status: 502,
-          text: () => Promise.resolve(""),
-        }),
-      );
-
-      const err = await client.getQuota().catch((e: unknown) => e);
-      expect(err).toBeInstanceOf(QURLAPIError);
-      expect(err).toMatchObject({
-        statusCode: 502,
-        code: "parse_error",
-      });
-    });
-
-    it("propagates network-level fetch failures", async () => {
-      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")));
-
-      await expect(client.listQURLs()).rejects.toThrow("fetch failed");
-    });
-
-    it("QURLAPIError has correct name property", () => {
-      const err = new QURLAPIError(400, "bad_request", "Bad request");
-      expect(err.name).toBe("QURLAPIError");
-      expect(err).toBeInstanceOf(Error);
-    });
-
-    it("QURLAPIError stores optional RFC 7807 fields", () => {
-      const err = new QURLAPIError(
-        400,
-        "invalid_request",
-        "Bad request",
-        "https://api.qurl.link/problems/invalid_request",
-        "/v1/qurls",
-        "req_123",
-      );
-      expect(err.type).toBe("https://api.qurl.link/problems/invalid_request");
-      expect(err.instance).toBe("/v1/qurls");
-      expect(err.requestId).toBe("req_123");
-    });
   });
 
-  describe("createQURL", () => {
-    it("sends POST to /v1/qurls with body", async () => {
-      const mockData = {
-        data: {
-          qurl_id: "q_3a7f2c8e91b",
-          resource_id: "r_abc123",
-          qurl_link: "https://qurl.link/at_token",
-          qurl_site: "https://q_3a7f2c8e91b.qurl.site",
-          expires_at: "2026-04-01T00:00:00Z",
-        },
-      };
-      const mock = stubFetch(mockData);
+  describe("shape translation", () => {
+    it("createQURL passes the input through and wraps the result in { data }", async () => {
+      sdk.create.mockResolvedValue({
+        qurl_id: "q_x",
+        resource_id: "r_x",
+        qurl_link: "https://qurl.link/#at_x",
+        qurl_site: "https://r_x.qurl.site",
+      });
+      const out = await newClient().createQURL({ target_url: "https://example.com" });
 
-      const input = {
-        target_url: "https://example.com",
-        label: "Test link",
-        expires_in: "24h",
-        one_time_use: false,
-        max_sessions: 3,
-      };
-      const result = await client.createQURL(input);
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify(input),
-        }),
-      );
-      expect(result).toEqual(mockData);
+      expect(sdk.create).toHaveBeenCalledWith({ target_url: "https://example.com" });
+      expect(out.data.qurl_id).toBe("q_x");
+      expect(out.data.resource_id).toBe("r_x");
     });
 
-    it("sends POST without optional fields", async () => {
-      const mock = stubFetch({ data: { qurl_id: "q_abc", resource_id: "r_abc" } });
-
-      await client.createQURL({ target_url: "https://example.com" });
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({ target_url: "https://example.com" }),
-        }),
-      );
-    });
-
-    it("sends access_policy in body", async () => {
-      const mock = stubFetch({ data: { qurl_id: "q_abc", resource_id: "r_abc" } });
-
-      const input = {
-        target_url: "https://example.com",
-        access_policy: {
-          ip_allowlist: ["192.168.1.0/24"],
-          geo_allowlist: ["US"],
-          ai_agent_policy: { deny_categories: ["gptbot"] },
-        },
-      };
-      await client.createQURL(input);
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls",
-        expect.objectContaining({
-          body: JSON.stringify(input),
-        }),
-      );
-    });
-  });
-
-  describe("getQURL", () => {
-    it("sends GET to /v1/qurls/:id", async () => {
-      const mockData = { data: { resource_id: "r_abc123", status: "active" } };
-      const mock = stubFetch(mockData);
-
-      const result = await client.getQURL("r_abc123");
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc123",
-        expect.objectContaining({ method: "GET", body: undefined }),
-      );
-      expect(result).toEqual(mockData);
-    });
-
-    it("URL-encodes the resource ID", async () => {
-      const mock = stubFetch({ data: {} });
-
-      await client.getQURL("r_abc/def");
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc%2Fdef",
-        expect.any(Object),
-      );
-    });
-  });
-
-  describe("listQURLs", () => {
-    it("sends GET to /v1/qurls with no query params by default", async () => {
-      const mockData = { data: [], meta: { has_more: false } };
-      const mock = stubFetch(mockData);
-
-      const result = await client.listQURLs();
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls",
-        expect.objectContaining({ method: "GET" }),
-      );
-      expect(result).toEqual(mockData);
-    });
-
-    it("sends limit and cursor as query params", async () => {
-      const mock = stubFetch({ data: [], meta: { has_more: false } });
-
-      await client.listQURLs({ limit: 10, cursor: "cur_xyz" });
-
-      const calledUrl = mock.mock.calls[0][0] as string;
-      expect(calledUrl).toContain("/v1/qurls?");
-      expect(calledUrl).toContain("limit=10");
-      expect(calledUrl).toContain("cursor=cur_xyz");
-    });
-
-    it("sends limit=0 as query param", async () => {
-      // The MCP tool schema rejects limit < 1 at the validation layer.
-      // This test covers the client method in isolation — an embedder that
-      // uses QURLClient directly (not via the MCP tool) gets the 0 through.
-      const mock = stubFetch({ data: [], meta: { has_more: false } });
-
-      await client.listQURLs({ limit: 0 });
-
-      const calledUrl = mock.mock.calls[0][0] as string;
-      expect(calledUrl).toContain("limit=0");
-    });
-
-    it("sends only limit when cursor is not provided", async () => {
-      const mock = stubFetch({ data: [], meta: { has_more: false } });
-
-      await client.listQURLs({ limit: 5 });
-
-      const calledUrl = mock.mock.calls[0][0] as string;
-      expect(calledUrl).toContain("limit=5");
-      expect(calledUrl).not.toContain("cursor");
-    });
-
-    it("sends no query params when input is empty object", async () => {
-      const mock = stubFetch({ data: [], meta: { has_more: false } });
-
-      await client.listQURLs({});
-
-      expect(mock).toHaveBeenCalledWith("https://api.test.com/v1/qurls", expect.any(Object));
-    });
-
-    it("sends filter query params", async () => {
-      const mock = stubFetch({ data: [], meta: { has_more: false } });
-
-      await client.listQURLs({
+    it("getQURL renames access_tokens → qurls and wraps in { data }", async () => {
+      sdk.get.mockResolvedValue({
+        resource_id: "r_x",
         status: "active",
-        created_after: "2026-01-01T00:00:00Z",
-        created_before: "2026-12-31T23:59:59Z",
-        expires_before: "2026-06-01T00:00:00Z",
-        expires_after: "2026-03-01T00:00:00Z",
-        sort: "created_at:desc",
-        q: "dashboard",
+        created_at: "t",
+        expires_at: "t",
+        access_tokens: [{ qurl_id: "q_a", status: "active" }],
       });
+      const out = await newClient().getQURL("r_x");
 
-      const calledUrl = mock.mock.calls[0][0] as string;
-      expect(calledUrl).toContain("status=active");
-      expect(calledUrl).toContain("created_after=2026-01-01T00%3A00%3A00Z");
-      expect(calledUrl).toContain("created_before=2026-12-31T23%3A59%3A59Z");
-      expect(calledUrl).toContain("expires_before=2026-06-01T00%3A00%3A00Z");
-      expect(calledUrl).toContain("expires_after=2026-03-01T00%3A00%3A00Z");
-      expect(calledUrl).toContain("sort=created_at%3Adesc");
-      expect(calledUrl).toContain("q=dashboard");
-    });
-  });
-
-  describe("deleteQURL", () => {
-    it("sends DELETE to /v1/qurls/:id", async () => {
-      const mock = stubFetch({});
-
-      await client.deleteQURL("r_abc123");
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc123",
-        expect.objectContaining({ method: "DELETE", body: undefined }),
-      );
+      expect(out.data.qurls).toEqual([{ qurl_id: "q_a", status: "active" }]);
+      expect((out.data as { access_tokens?: unknown }).access_tokens).toBeUndefined();
     });
 
-    it("returns void on success", async () => {
-      stubFetch({});
-
-      const result = await client.deleteQURL("r_abc123");
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe("updateQURL", () => {
-    it("sends PATCH to /v1/qurls/:id with extend_by body", async () => {
-      const mockData = { data: { resource_id: "r_abc", expires_at: "2026-04-01T00:00:00Z" } };
-      const mock = stubFetch(mockData);
-
-      const result = await client.updateQURL("r_abc", { extend_by: "48h" });
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc",
-        expect.objectContaining({
-          method: "PATCH",
-          body: JSON.stringify({ extend_by: "48h" }),
-        }),
-      );
-      expect(result).toEqual(mockData);
-    });
-
-    it("sends PATCH with expires_at", async () => {
-      const mockData = { data: { resource_id: "r_abc", expires_at: "2026-04-01T00:00:00Z" } };
-      const mock = stubFetch(mockData);
-
-      await client.updateQURL("r_abc", { expires_at: "2026-04-01T00:00:00Z" });
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc",
-        expect.objectContaining({
-          body: JSON.stringify({ expires_at: "2026-04-01T00:00:00Z" }),
-        }),
-      );
-    });
-
-    it("sends PATCH with tags and description", async () => {
-      const mock = stubFetch({ data: { resource_id: "r_abc" } });
-
-      await client.updateQURL("r_abc", {
-        tags: ["prod", "api"],
-        description: "Updated description",
+    it("listQURLs reshapes the SDK envelope into { data, meta } and maps each item", async () => {
+      sdk.list.mockResolvedValue({
+        qurls: [{ resource_id: "r_x", access_tokens: [] }],
+        next_cursor: "c2",
+        has_more: true,
       });
+      const out = await newClient().listQURLs({ limit: 10 });
 
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc",
-        expect.objectContaining({
-          body: JSON.stringify({ tags: ["prod", "api"], description: "Updated description" }),
-        }),
-      );
+      expect(sdk.list).toHaveBeenCalledWith({ limit: 10 });
+      expect(out.data[0].qurls).toEqual([]);
+      expect((out.data[0] as { access_tokens?: unknown }).access_tokens).toBeUndefined();
+      expect(out.meta).toEqual({ next_cursor: "c2", has_more: true });
     });
-  });
 
-  describe("updateResource", () => {
-    it("sends PATCH to /v1/resources/:id with resource metadata body", async () => {
-      const mockData = { data: { resource_id: "r_abc", custom_domain: "app.example.com" } };
-      const mock = stubFetch(mockData);
-
-      const result = await client.updateResource("r_abc", {
-        custom_domain: "app.example.com",
-        preserve_host: true,
+    it("batchCreate flattens the SDK output into { data, meta }", async () => {
+      sdk.batchCreate.mockResolvedValue({
+        succeeded: 1,
+        failed: 0,
+        results: [{ index: 0, success: true, resource_id: "r_x", qurl_link: "L", qurl_site: "S" }],
+        request_id: "req_1",
       });
+      const out = await newClient().batchCreate({ items: [{ target_url: "https://example.com" }] });
 
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/resources/r_abc",
-        expect.objectContaining({
-          method: "PATCH",
-          body: JSON.stringify({ custom_domain: "app.example.com", preserve_host: true }),
-        }),
-      );
-      expect(result).toEqual(mockData);
-    });
-  });
-
-  describe("resolveQURL", () => {
-    it("sends POST to /v1/resolve with access_token", async () => {
-      const mockData = {
-        data: {
-          target_url: "https://example.com",
-          resource_id: "r_abc",
-          access_grant: {
-            expires_in: 300,
-            granted_at: "2026-03-09T00:00:00Z",
-            src_ip: "1.2.3.4",
-          },
-        },
-      };
-      const mock = stubFetch(mockData);
-
-      const result = await client.resolveQURL({ access_token: "at_token123" });
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/resolve",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({ access_token: "at_token123" }),
-        }),
-      );
-      expect(result).toEqual(mockData);
-    });
-  });
-
-  describe("getQuota", () => {
-    it("sends GET to /v1/quota", async () => {
-      const mockData = {
-        data: {
-          plan: "growth",
-          period_start: "2026-03-01T00:00:00Z",
-          period_end: "2026-04-01T00:00:00Z",
-          rate_limits: {
-            create_per_minute: 200,
-            create_per_hour: 10000,
-            list_per_minute: 120,
-            resolve_per_minute: 300,
-            max_active_qurls: 1000,
-            max_tokens_per_qurl: 50,
-            max_expiry_seconds: 2592000,
-          },
-          usage: {
-            qurls_created: 150,
-            active_qurls: 45,
-            active_qurls_percent: 0.45,
-            total_accesses: 1250,
-          },
-        },
-      };
-      const mock = stubFetch(mockData);
-
-      const result = await client.getQuota();
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/quota",
-        expect.objectContaining({ method: "GET" }),
-      );
-      expect(result).toEqual(mockData);
-    });
-  });
-
-  describe("mintLink", () => {
-    it("sends POST to /v1/qurls/:id/mint_link", async () => {
-      const mockData = {
-        data: {
-          qurl_link: "https://qurl.link/at_newtoken",
-          expires_at: "2026-04-01T00:00:00Z",
-        },
-      };
-      const mock = stubFetch(mockData);
-
-      const result = await client.mintLink("r_abc123", { label: "Alice" });
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc123/mint_link",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({ label: "Alice" }),
-        }),
-      );
-      expect(result).toEqual(mockData);
+      expect(out.data.succeeded).toBe(1);
+      expect(out.data.failed).toBe(0);
+      expect(out.data.results).toHaveLength(1);
+      expect(out.meta.request_id).toBe("req_1");
     });
 
-    it("sends an empty JSON body when no input provided", async () => {
-      const mock = stubFetch({ data: { qurl_link: "https://qurl.link/at_x" } });
-
-      await client.mintLink("r_abc123");
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc123/mint_link",
-        expect.objectContaining({
-          body: JSON.stringify({}),
-        }),
-      );
-      const headers = (mock.mock.calls[0][1] as { headers: Record<string, string> }).headers;
-      expect(headers).toHaveProperty("Content-Type", "application/json");
-    });
-
-    it("URL-encodes the resource ID", async () => {
-      const mock = stubFetch({ data: {} });
-
-      await client.mintLink("r_abc/def");
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/r_abc%2Fdef/mint_link",
-        expect.any(Object),
-      );
-    });
-  });
-
-  describe("batchCreate", () => {
-    it("sends POST to /v1/qurls/batch with items", async () => {
-      const mockData = {
-        data: {
-          succeeded: 2,
-          failed: 0,
-          results: [
-            { index: 0, success: true, resource_id: "r_abc", qurl_link: "https://qurl.link/at_1" },
-            { index: 1, success: true, resource_id: "r_def", qurl_link: "https://qurl.link/at_2" },
-          ],
-        },
-        meta: { request_id: "req_batch1" },
-      };
-      const mock = stubFetch(mockData);
-
-      const input = {
-        items: [
-          { target_url: "https://app1.example.com", expires_in: "7d" },
-          { target_url: "https://app2.example.com", expires_in: "24h" },
-        ],
-      };
-      const result = await client.batchCreate(input);
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/qurls/batch",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify(input),
-        }),
-      );
-      expect(result).toEqual(mockData);
-    });
-
-    it("returns partial success results", async () => {
-      const mockData = {
-        data: {
-          succeeded: 1,
-          failed: 1,
-          results: [
-            { index: 0, success: true, resource_id: "r_abc", qurl_link: "https://qurl.link/at_1" },
-            {
-              index: 1,
-              success: false,
-              error: { code: "invalid_target_url", message: "Invalid URL" },
-            },
-          ],
-        },
-        meta: { request_id: "req_batch2" },
-      };
-      stubFetch(mockData, 207);
-
-      const result = await client.batchCreate({
-        items: [{ target_url: "https://valid.example.com" }, { target_url: "not-a-url" }],
+    it("listResourceSessions maps sessions → data", async () => {
+      sdk.listResourceSessions.mockResolvedValue({
+        sessions: [{ session_id: "s1", qurl_id: "q_a" }],
+        request_id: "req_2",
       });
+      const out = await newClient().listResourceSessions("r_x");
 
-      expect(result.data.succeeded).toBe(1);
-      expect(result.data.failed).toBe(1);
-      expect(result.data.results[1].error?.code).toBe("invalid_target_url");
+      expect(out.data).toEqual([{ session_id: "s1", qurl_id: "q_a" }]);
+      expect(out.meta).toEqual({ request_id: "req_2" });
     });
 
-    it("passes through the structured body on HTTP 400 (all items failed)", async () => {
-      // When every batch item fails validation the API returns 400 with a
-      // BatchCreateResponse body, not an error envelope. The client must
-      // surface the per-item errors instead of throwing a generic "HTTP 400".
-      const mockData = {
-        data: {
-          succeeded: 0,
-          failed: 2,
-          results: [
-            {
-              index: 0,
-              success: false,
-              error: { code: "invalid_input", message: "items[0]: target_url must be HTTPS" },
-            },
-            {
-              index: 1,
-              success: false,
-              error: { code: "invalid_input", message: "items[1]: target_url must be HTTPS" },
-            },
-          ],
-        },
-        meta: { request_id: "req_batch_fail" },
-      };
-      stubFetch(mockData, 400);
+    it("terminateAllResourceSessions wraps the count in { data }", async () => {
+      sdk.terminateAllResourceSessions.mockResolvedValue({ terminated: 3, request_id: "req_3" });
+      const out = await newClient().terminateAllResourceSessions("r_x");
 
-      const result = await client.batchCreate({
-        items: [
-          { target_url: "http://insecure1.example.com" },
-          { target_url: "http://insecure2.example.com" },
-        ],
-      });
-
-      expect(result.data.failed).toBe(2);
-      expect(result.data.succeeded).toBe(0);
-      expect(result.data.results[0].error?.message).toContain("target_url must be HTTPS");
-      expect(result.data.results[1].error?.message).toContain("target_url must be HTTPS");
-      expect(result.meta.request_id).toBe("req_batch_fail");
-    });
-
-    it("still throws on non-400 batch errors (e.g., 401, 429, 5xx)", async () => {
-      stubFetch(
-        {
-          error: {
-            type: "https://api.qurl.link/problems/unauthorized",
-            title: "Unauthorized",
-            status: 401,
-            code: "unauthorized",
-          },
-        },
-        401,
-      );
-
-      await expect(
-        client.batchCreate({ items: [{ target_url: "https://example.com" }] }),
-      ).rejects.toThrow(QURLAPIError);
+      expect(out.data.terminated).toBe(3);
+      expect(out.meta).toEqual({ request_id: "req_3" });
     });
   });
 
-  describe("resource qURL tokens", () => {
-    it("sends DELETE to /v1/resources/:id/qurls/:qurl_id", async () => {
-      const mock = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 204,
-        text: () => Promise.resolve(""),
-      });
-      vi.stubGlobal("fetch", mock);
-
-      const result = await client.revokeQurlToken("r_abc123def45", "q_abc123def45");
-
-      expect(result).toBeUndefined();
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/resources/r_abc123def45/qurls/q_abc123def45",
-        expect.objectContaining({ method: "DELETE", body: undefined }),
-      );
+  describe("method renames", () => {
+    it("revokeQurlToken delegates to sdk.revokeResourceQurl", async () => {
+      sdk.revokeResourceQurl.mockResolvedValue(undefined);
+      await newClient().revokeQurlToken("r_x", "q_y");
+      expect(sdk.revokeResourceQurl).toHaveBeenCalledWith("r_x", "q_y");
     });
 
-    it("sends PATCH to /v1/resources/:id/qurls/:qurl_id", async () => {
-      const mockData = {
-        data: {
-          qurl_id: "q_abc123def45",
-          status: "active",
-          one_time_use: false,
-          max_sessions: 5,
-          session_duration: 3600,
-          use_count: 0,
-          created_at: "2026-06-01T00:00:00Z",
-          expires_at: "2026-06-02T00:00:00Z",
-        },
-      };
-      const mock = stubFetch(mockData);
+    it("updateQurlToken delegates to sdk.updateResourceQurl and wraps in { data }", async () => {
+      sdk.updateResourceQurl.mockResolvedValue({ qurl_id: "q_y", status: "active" });
+      const out = await newClient().updateQurlToken("r_x", "q_y", { label: "renamed" });
 
-      const result = await client.updateQurlToken("r_abc123def45", "q_abc123def45", {
-        max_sessions: 5,
-      });
+      expect(sdk.updateResourceQurl).toHaveBeenCalledWith("r_x", "q_y", { label: "renamed" });
+      expect(out.data.qurl_id).toBe("q_y");
+    });
+  });
 
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/resources/r_abc123def45/qurls/q_abc123def45",
-        expect.objectContaining({
-          method: "PATCH",
-          body: JSON.stringify({ max_sessions: 5 }),
+  describe("error translation", () => {
+    it("maps an SDK NotFoundError to QURLAPIError with statusCode 404 (delete-qurl branch)", async () => {
+      sdk.delete.mockRejectedValue(
+        new NotFoundError({
+          status: 404,
+          code: "resource_not_found",
+          title: "Not Found",
+          detail: "gone",
         }),
       );
-      expect(result).toEqual(mockData);
+      const err = (await newClient()
+        .deleteQURL("r_x")
+        .catch((e: unknown) => e)) as QURLAPIError;
+
+      expect(err).toBeInstanceOf(QURLAPIError);
+      expect(err.statusCode).toBe(404);
+      expect(err.code).toBe("resource_not_found");
+      expect(err.message).toBe("gone");
     });
 
-    it("URL-encodes resource and qURL IDs", async () => {
-      const mock = stubFetch({ data: {} });
-
-      await client.updateQurlToken("r_abc/def", "q_abc/def", { label: "Alice" });
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/resources/r_abc%2Fdef/qurls/q_abc%2Fdef",
-        expect.any(Object),
+    it("preserves code and requestId when translating a 403", async () => {
+      sdk.create.mockRejectedValue(
+        new AuthorizationError({
+          status: 403,
+          code: "insufficient_scope",
+          title: "Forbidden",
+          detail: "missing qurl:write",
+          request_id: "req_9",
+        }),
       );
-    });
-  });
+      const err = (await newClient()
+        .createQURL({ target_url: "https://example.com" })
+        .catch((e: unknown) => e)) as QURLAPIError;
 
-  describe("resource sessions", () => {
-    it("sends GET to /v1/resources/:id/sessions", async () => {
-      const mockData = {
-        data: [{ session_id: "sess_1", qurl_id: "q_abc123def45" }],
-        meta: { request_id: "req_sessions" },
-      };
-      const mock = stubFetch(mockData);
-
-      const result = await client.listResourceSessions("r_abc123def45");
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/resources/r_abc123def45/sessions",
-        expect.objectContaining({ method: "GET", body: undefined }),
-      );
-      expect(result).toEqual(mockData);
-    });
-
-    it("sends DELETE to /v1/resources/:id/sessions/:session_id", async () => {
-      const mock = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 204,
-        text: () => Promise.resolve(""),
-      });
-      vi.stubGlobal("fetch", mock);
-
-      const result = await client.terminateResourceSession("r_abc123def45", "sess_1");
-
-      expect(result).toBeUndefined();
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/resources/r_abc123def45/sessions/sess_1",
-        expect.objectContaining({ method: "DELETE", body: undefined }),
-      );
-    });
-
-    it("sends DELETE to /v1/resources/:id/sessions for all sessions", async () => {
-      const mockData = { data: { terminated: 3 }, meta: { request_id: "req_term" } };
-      const mock = stubFetch(mockData);
-
-      const result = await client.terminateAllResourceSessions("r_abc123def45");
-
-      expect(mock).toHaveBeenCalledWith(
-        "https://api.test.com/v1/resources/r_abc123def45/sessions",
-        expect.objectContaining({ method: "DELETE", body: undefined }),
-      );
-      expect(result).toEqual(mockData);
+      expect(err).toBeInstanceOf(QURLAPIError);
+      expect(err.statusCode).toBe(403);
+      expect(err.code).toBe("insufficient_scope");
+      expect(err.requestId).toBe("req_9");
     });
   });
 });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -119,6 +119,23 @@ describe("QURLClient adapter", () => {
       expect((out.data as { access_tokens?: unknown }).access_tokens).toBeUndefined();
     });
 
+    it("extendQURL delegates to sdk.extend and maps the resource result", async () => {
+      // extend changed code paths (old client delegated to updateQURL); confirm
+      // it hits sdk.extend and the resource is mapped (access_tokens → qurls).
+      sdk.extend.mockResolvedValue({
+        resource_id: "r_x",
+        status: "active",
+        created_at: "t",
+        expires_at: "t2",
+        access_tokens: [{ qurl_id: "q_a", status: "active" }],
+      });
+      const out = await newClient().extendQURL("r_x", { extend_by: "24h" });
+
+      expect(sdk.extend).toHaveBeenCalledWith("r_x", { extend_by: "24h" });
+      expect(out.data.qurls).toEqual([{ qurl_id: "q_a", status: "active" }]);
+      expect((out.data as { access_tokens?: unknown }).access_tokens).toBeUndefined();
+    });
+
     it("listQURLs reshapes the SDK envelope into { data, meta } and maps each item", async () => {
       sdk.list.mockResolvedValue({
         qurls: [{ resource_id: "r_x", access_tokens: [] }],
@@ -146,6 +163,30 @@ describe("QURLClient adapter", () => {
       expect(out.data.failed).toBe(0);
       expect(out.data.results).toHaveLength(1);
       expect(out.meta.request_id).toBe("req_1");
+    });
+
+    it("batchCreate surfaces the all-failed (HTTP 400 passthrough) case as failed > 0", async () => {
+      // The SDK passes through HTTP 400 (every item failed) as a populated
+      // BatchCreateOutput instead of throwing; the adapter must reshape it,
+      // not let it surface as a thrown JSON-RPC error.
+      sdk.batchCreate.mockResolvedValue({
+        succeeded: 0,
+        failed: 2,
+        results: [
+          { index: 0, success: false, error: { code: "invalid_input", message: "non-https" } },
+          { index: 1, success: false, error: { code: "invalid_input", message: "non-https" } },
+        ],
+        request_id: "req_fail",
+      });
+      const out = await newClient().batchCreate({
+        items: [{ target_url: "ftp://a" }, { target_url: "ftp://b" }],
+      });
+
+      expect(out.data.succeeded).toBe(0);
+      expect(out.data.failed).toBe(2);
+      expect(out.data.results).toHaveLength(2);
+      expect(out.data.results[0].success).toBe(false);
+      expect(out.meta.request_id).toBe("req_fail");
     });
 
     it("listResourceSessions maps sessions → data", async () => {

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -207,6 +207,50 @@ describe("QURLClient adapter", () => {
       expect(out.data.terminated).toBe(3);
       expect(out.meta).toEqual({ request_id: "req_3" });
     });
+
+    // The remaining methods are single-`as` passthrough wrappers; one assertion
+    // each locks the delegation + `{ data }` wrapping at the adapter layer.
+
+    it("resolveQURL passes the token through and wraps in { data }", async () => {
+      sdk.resolve.mockResolvedValue({
+        target_url: "https://example.com",
+        resource_id: "r_x",
+        access_grant: { expires_in: 300, granted_at: "t", src_ip: "1.2.3.4" },
+      });
+      const out = await newClient().resolveQURL({ access_token: "at_x" });
+
+      expect(sdk.resolve).toHaveBeenCalledWith({ access_token: "at_x" });
+      expect(out.data.target_url).toBe("https://example.com");
+    });
+
+    it("getQuota wraps the SDK quota in { data }", async () => {
+      sdk.getQuota.mockResolvedValue({ plan: "growth", period_start: "a", period_end: "b" });
+      const out = await newClient().getQuota();
+
+      expect(out.data.plan).toBe("growth");
+    });
+
+    it("mintLink passes the input through and wraps in { data }", async () => {
+      sdk.mintLink.mockResolvedValue({ qurl_id: "q_x", qurl_link: "L", expires_at: "t" });
+      const out = await newClient().mintLink("r_x", { label: "for Alice" });
+
+      expect(sdk.mintLink).toHaveBeenCalledWith("r_x", { label: "for Alice" });
+      expect(out.data.qurl_id).toBe("q_x");
+    });
+
+    it("updateResource maps the resource result (access_tokens → qurls)", async () => {
+      sdk.updateResource.mockResolvedValue({
+        resource_id: "r_x",
+        status: "active",
+        created_at: "t",
+        expires_at: "t",
+        access_tokens: [],
+      });
+      const out = await newClient().updateResource("r_x", { description: "d" });
+
+      expect(sdk.updateResource).toHaveBeenCalledWith("r_x", { description: "d" });
+      expect(out.data.qurls).toEqual([]);
+    });
   });
 
   describe("method renames", () => {

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -238,6 +238,12 @@ describe("QURLClient adapter", () => {
       expect(out.data.qurl_id).toBe("q_x");
     });
 
+    it("mintLink with no input passes undefined through to the SDK", async () => {
+      sdk.mintLink.mockResolvedValue({ qurl_id: "q_x", qurl_link: "L", expires_at: "t" });
+      await newClient().mintLink("r_x");
+      expect(sdk.mintLink).toHaveBeenCalledWith("r_x", undefined);
+    });
+
     it("updateResource maps the resource result (access_tokens → qurls)", async () => {
       sdk.updateResource.mockResolvedValue({
         resource_id: "r_x",

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -44,7 +44,7 @@ vi.mock("@layervai/qurl", async (importOriginal) => {
 });
 
 import { QURLClient, QURLAPIError, MISSING_API_KEY_MESSAGE } from "../client.js";
-import { NotFoundError, AuthorizationError } from "@layervai/qurl";
+import { NotFoundError, AuthorizationError, NetworkError } from "@layervai/qurl";
 
 const newClient = (apiKey = "lv_live_key", baseURL = "https://api.test.layerv.ai") =>
   new QURLClient({ apiKey, baseURL });
@@ -307,6 +307,20 @@ describe("QURLClient adapter", () => {
       expect(err.statusCode).toBe(403);
       expect(err.code).toBe("insufficient_scope");
       expect(err.requestId).toBe("req_9");
+    });
+
+    it("translates a transport-level SDK error (NetworkError) to QURLAPIError", async () => {
+      // All SDK error subclasses — including transport/timeout failures —
+      // extend QURLError, so translateError catches them too (status 0). This
+      // matters for delete-qurl, which only swallows QURLAPIError instances.
+      sdk.get.mockRejectedValue(new NetworkError("connection refused"));
+      const err = (await newClient()
+        .getQURL("r_x")
+        .catch((e: unknown) => e)) as QURLAPIError;
+
+      expect(err).toBeInstanceOf(QURLAPIError);
+      expect(err.statusCode).toBe(0);
+      expect(err.code).toBe("network_error");
     });
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,15 +11,8 @@
 
 import { QURLClient as SDKQURLClient, QURLError } from "@layervai/qurl";
 import type {
-  BatchCreateInput as SDKBatchCreateInput,
-  CreateInput as SDKCreateInput,
-  ExtendInput as SDKExtendInput,
-  ListInput as SDKListInput,
-  MintInput as SDKMintInput,
   QURL as SDKQURL,
   Resource as SDKResource,
-  UpdateInput as SDKUpdateInput,
-  UpdateResourceInput as SDKUpdateResourceInput,
   UpdateResourceQurlInput as SDKUpdateResourceQurlInput,
 } from "@layervai/qurl";
 
@@ -382,12 +375,16 @@ function translateError(err: unknown): unknown {
     return new QURLAPIError(
       err.status,
       err.code,
-      err.detail || err.message,
+      // `QURLError.detail` is non-optional and always populated (the SDK falls
+      // back to `title` when the API omits detail), so it carries the same
+      // human-readable text the old client's detail/title/message chain did.
+      err.detail,
       err.type,
       err.instance,
       err.requestId,
-      // The SDK surfaces tombstone metadata (410 path) on the error when the
-      // API returns it; absent on the SDK's error type, this is simply undefined.
+      // 410 tombstone metadata: the SDK's QURLError does not currently surface
+      // it, so this is always undefined. Kept for forward-compat and because
+      // QURLAPIError carries the field; no MCP tool reads it today.
       (err as { tombstone?: TombstoneInfo }).tombstone,
     );
   }
@@ -398,10 +395,13 @@ function translateError(err: unknown): unknown {
  * Map an SDK resource read (`QURL`/`Resource`) onto the MCP's `QURL` shape.
  * The only structural difference is the field name for the nested tokens:
  * the SDK exposes `access_tokens`, the MCP's output schemas validate `qurls`.
+ * When the SDK omits `access_tokens`, the key is dropped entirely rather than
+ * surfaced as `qurls: undefined`.
  */
 function mapResource(raw: SDKQURL | SDKResource): QURL {
   const { access_tokens, ...rest } = raw as SDKQURL;
-  return { ...rest, qurls: access_tokens } as unknown as QURL;
+  const mapped = access_tokens === undefined ? rest : { ...rest, qurls: access_tokens };
+  return mapped as unknown as QURL;
 }
 
 // --- Client implementation ---
@@ -460,10 +460,17 @@ export class QURLClient implements IQURLClient {
     }
   }
 
+  // Casts at the SDK boundary are kept as tight as the compiler allows:
+  // inputs pass through unannotated where the MCP type is structurally
+  // assignable to the SDK type (a genuine drift then fails to compile), and
+  // outputs use a single `as` (not `as unknown as`) so a grossly incompatible
+  // SDK return is still rejected. `mapResource`'s `QURL`/`Resource` → MCP
+  // `QURL` conversion is the one place a double cast is genuinely required.
+  // The tools additionally validate every `structuredContent` against their
+  // zod `outputSchema`, so any residual response drift surfaces at runtime.
+
   async createQURL(input: CreateQURLInput): Promise<{ data: CreateQURLData }> {
-    return this.call(async (sdk) => ({
-      data: (await sdk.create(input as unknown as SDKCreateInput)) as unknown as CreateQURLData,
-    }));
+    return this.call(async (sdk) => ({ data: (await sdk.create(input)) as CreateQURLData }));
   }
 
   async getQURL(id: string): Promise<{ data: QURL }> {
@@ -472,7 +479,10 @@ export class QURLClient implements IQURLClient {
 
   async listQURLs(input?: ListQURLsInput): Promise<ListQURLsOutput> {
     return this.call(async (sdk) => {
-      const out = await sdk.list(input as unknown as SDKListInput);
+      const out = await sdk.list(input);
+      // The SDK's list envelope is `{ qurls, next_cursor, has_more }` and does
+      // not surface `meta.page_size` / `meta.request_id` (both optional in the
+      // output schema), so they are intentionally absent here.
       return {
         data: out.qurls.map(mapResource),
         meta: { next_cursor: out.next_cursor, has_more: out.has_more },
@@ -485,47 +495,41 @@ export class QURLClient implements IQURLClient {
   }
 
   async updateQURL(id: string, input: UpdateQURLInput): Promise<{ data: QURL }> {
-    return this.call(async (sdk) => ({
-      data: mapResource(await sdk.update(id, input as unknown as SDKUpdateInput)),
-    }));
+    return this.call(async (sdk) => ({ data: mapResource(await sdk.update(id, input)) }));
   }
 
   async updateResource(id: string, input: UpdateResourceInput): Promise<{ data: QURL }> {
-    return this.call(async (sdk) => ({
-      data: mapResource(await sdk.updateResource(id, input as unknown as SDKUpdateResourceInput)),
-    }));
+    return this.call(async (sdk) => ({ data: mapResource(await sdk.updateResource(id, input)) }));
   }
 
   async extendQURL(id: string, input: ExtendQURLInput): Promise<{ data: QURL }> {
-    return this.call(async (sdk) => ({
-      data: mapResource(await sdk.extend(id, input as unknown as SDKExtendInput)),
-    }));
+    return this.call(async (sdk) => ({ data: mapResource(await sdk.extend(id, input)) }));
   }
 
   async resolveQURL(input: ResolveInput): Promise<{ data: ResolveOutput }> {
-    return this.call(async (sdk) => ({
-      data: (await sdk.resolve(input)) as unknown as ResolveOutput,
-    }));
+    return this.call(async (sdk) => ({ data: (await sdk.resolve(input)) as ResolveOutput }));
   }
 
   async getQuota(): Promise<{ data: QuotaOutput }> {
-    return this.call(async (sdk) => ({ data: (await sdk.getQuota()) as unknown as QuotaOutput }));
+    return this.call(async (sdk) => ({ data: (await sdk.getQuota()) as QuotaOutput }));
   }
 
   async mintLink(id: string, input?: MintLinkInput): Promise<{ data: MintLinkOutput }> {
-    return this.call(async (sdk) => ({
-      data: (await sdk.mintLink(id, input as unknown as SDKMintInput)) as unknown as MintLinkOutput,
-    }));
+    return this.call(async (sdk) => ({ data: (await sdk.mintLink(id, input)) as MintLinkOutput }));
   }
 
   async batchCreate(input: BatchCreateInput): Promise<BatchCreateOutput> {
     return this.call(async (sdk) => {
-      const out = await sdk.batchCreate(input as unknown as SDKBatchCreateInput);
+      // The SDK passes through HTTP 400 (all items failed) as a populated
+      // BatchCreateOutput rather than throwing, so the all-failed case still
+      // reaches here with `failed > 0` — matching the old passthrough behavior
+      // that batch-create.ts depends on.
+      const out = await sdk.batchCreate(input);
       return {
         data: {
           succeeded: out.succeeded,
           failed: out.failed,
-          results: out.results as unknown as BatchItemResult[],
+          results: out.results as BatchItemResult[],
         },
         meta: { request_id: out.request_id },
       };
@@ -542,11 +546,14 @@ export class QURLClient implements IQURLClient {
     input: UpdateQurlTokenInput,
   ): Promise<{ data: AccessToken }> {
     return this.call(async (sdk) => ({
+      // The SDK types this input as an extend_by-XOR-expires_at discriminated
+      // union; the MCP's UpdateQurlTokenInput allows both fields and enforces
+      // the XOR via a zod refinement in update-qurl-token.ts, so bridge here.
       data: (await sdk.updateResourceQurl(
         resourceId,
         qurlId,
         input as unknown as SDKUpdateResourceQurlInput,
-      )) as unknown as AccessToken,
+      )) as AccessToken,
     }));
   }
 
@@ -554,7 +561,7 @@ export class QURLClient implements IQURLClient {
     return this.call(async (sdk) => {
       const out = await sdk.listResourceSessions(resourceId);
       return {
-        data: out.sessions as unknown as SessionData[],
+        data: out.sessions as SessionData[],
         meta: { request_id: out.request_id },
       };
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -351,7 +351,8 @@ export class QURLAPIError extends Error {
 
 /**
  * Shared message for the missing-API-key condition. Emitted both at boot
- * (stderr warning in `index.ts`) and on every API call from `request()`.
+ * (stderr warning in `index.ts`) and on every API call (the lazy `sdk` getter
+ * throws it when no key is configured).
  * Keeping a single string means a user grepping logs/transcripts hits the
  * same phrase from both sites, and the CI introspection probe has a stable
  * substring to assert against.

--- a/src/client.ts
+++ b/src/client.ts
@@ -401,7 +401,11 @@ function translateError(err: unknown): unknown {
  */
 function mapResource(raw: SDKQURL | SDKResource): QURL {
   const { access_tokens, ...rest } = raw as SDKQURL;
-  const mapped = access_tokens === undefined ? rest : { ...rest, qurls: access_tokens };
+  // Drop the key for both `undefined` and a defensive `null`.
+  const mapped =
+    access_tokens === undefined || access_tokens === null
+      ? rest
+      : { ...rest, qurls: access_tokens };
   return mapped as unknown as QURL;
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,27 @@
 /**
  * qURL API client for the MCP server.
+ *
+ * The exported `QURLClient` is a thin adapter over the published
+ * `@layervai/qurl` SDK: the SDK owns all HTTP, retry, and error-parsing
+ * behavior, and this file translates between the SDK's surface and the local
+ * domain types/`IQURLClient` contract the tools, resources, and output schemas
+ * are written against (`{ data }` wrapping, the `qurls` field name, and the
+ * `QURLAPIError` error class).
  */
+
+import { QURLClient as SDKQURLClient, QURLError } from "@layervai/qurl";
+import type {
+  BatchCreateInput as SDKBatchCreateInput,
+  CreateInput as SDKCreateInput,
+  ExtendInput as SDKExtendInput,
+  ListInput as SDKListInput,
+  MintInput as SDKMintInput,
+  QURL as SDKQURL,
+  Resource as SDKResource,
+  UpdateInput as SDKUpdateInput,
+  UpdateResourceInput as SDKUpdateResourceInput,
+  UpdateResourceQurlInput as SDKUpdateResourceQurlInput,
+} from "@layervai/qurl";
 
 export interface QURLClientConfig {
   apiKey: string;
@@ -345,11 +366,64 @@ export class QURLAPIError extends Error {
 export const MISSING_API_KEY_MESSAGE =
   "QURL_API_KEY is not set. Set it in the MCP server environment and restart to make API calls.";
 
+// --- SDK adapter helpers ---
+
+/**
+ * Translate an error thrown by the SDK into the `QURLAPIError` the MCP tools
+ * branch on. Two consumers depend on the exact fields: `delete-qurl` checks
+ * `statusCode === 404`, and `withMissingApiKeyHandler` checks
+ * `code === "missing_api_key"`. A `QURLAPIError` we raised ourselves (the
+ * missing-key pre-flight) passes through untouched; anything that isn't a
+ * `QURLError` is returned as-is.
+ */
+function translateError(err: unknown): unknown {
+  if (err instanceof QURLAPIError) return err;
+  if (err instanceof QURLError) {
+    return new QURLAPIError(
+      err.status,
+      err.code,
+      err.detail || err.message,
+      err.type,
+      err.instance,
+      err.requestId,
+      // The SDK surfaces tombstone metadata (410 path) on the error when the
+      // API returns it; absent on the SDK's error type, this is simply undefined.
+      (err as { tombstone?: TombstoneInfo }).tombstone,
+    );
+  }
+  return err;
+}
+
+/**
+ * Map an SDK resource read (`QURL`/`Resource`) onto the MCP's `QURL` shape.
+ * The only structural difference is the field name for the nested tokens:
+ * the SDK exposes `access_tokens`, the MCP's output schemas validate `qurls`.
+ */
+function mapResource(raw: SDKQURL | SDKResource): QURL {
+  const { access_tokens, ...rest } = raw as SDKQURL;
+  return { ...rest, qurls: access_tokens } as unknown as QURL;
+}
+
 // --- Client implementation ---
 
+/**
+ * Adapter implementing {@link IQURLClient} over the `@layervai/qurl` SDK.
+ *
+ * The SDK owns HTTP, retries, and error parsing. This class only translates
+ * shapes (re-wraps the SDK's unwrapped returns into `{ data }`, renames
+ * `access_tokens` → `qurls`, reshapes list/batch/session envelopes) and maps
+ * the SDK's `QURLError` subclasses onto `QURLAPIError`.
+ */
 export class QURLClient implements IQURLClient {
-  private apiKey: string;
-  private baseURL: string;
+  private readonly apiKey: string;
+  private readonly baseURL: string;
+  /**
+   * Constructed lazily on first API call. The SDK constructor throws on an
+   * empty key, but `index.ts` deliberately boots the server keyless so MCP
+   * introspection (tools/list, resources/list, prompts/list) works without a
+   * configured key — the missing-key error must defer to the first real call.
+   */
+  private _sdk?: SDKQURLClient;
 
   constructor(config: QURLClientConfig) {
     // `?? ""` defends against JS callers that hand in `undefined` (the TS
@@ -362,160 +436,104 @@ export class QURLClient implements IQURLClient {
   }
 
   /**
-   * Issue an HTTP request and parse the JSON response.
-   *
-   * `passthroughStatuses` lets a caller opt certain non-2xx codes out of the
-   * default throw-on-error path and receive the parsed body instead. This is
-   * used by `batchCreate`, where the API returns a structured BatchCreateResponse
-   * on HTTP 400 (all items rejected) — throwing would drop the per-item errors.
+   * Lazily build the SDK client. Throws the typed `missing_api_key` error
+   * (status 0) when no key is configured, matching the pre-SDK behavior that
+   * `withMissingApiKeyHandler` and the CI introspection probe rely on. Note
+   * the SDK option is `baseUrl` (lowercase) vs. the MCP config's `baseURL`.
    */
-  private async request<T>(
-    method: string,
-    path: string,
-    body?: unknown,
-    passthroughStatuses: number[] = [],
-  ): Promise<T> {
+  private get sdk(): SDKQURLClient {
     if (!this.apiKey) {
       throw new QURLAPIError(0, "missing_api_key", MISSING_API_KEY_MESSAGE);
     }
-
-    const url = `${this.baseURL}${path}`;
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${this.apiKey}`,
-    };
-    if (body !== undefined) {
-      headers["Content-Type"] = "application/json";
+    if (!this._sdk) {
+      this._sdk = new SDKQURLClient({ apiKey: this.apiKey, baseUrl: this.baseURL });
     }
-
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    });
-
-    const text = await response.text();
-
-    // Handle empty 2xx responses (e.g., 204 No Content from DELETE).
-    // Only deleteQURL hits this path — T is void there, so undefined is correct.
-    if (!text && response.ok) {
-      return undefined as T;
-    }
-
-    const json = this.parseJSON(text, response.status);
-
-    if (!response.ok && !passthroughStatuses.includes(response.status)) {
-      // Trust boundary: we cast the parsed error body to the RFC 7807 shape
-      // the API documents. The fallback chain below tolerates missing fields,
-      // so a malformed error response still degrades to `HTTP ${status}`.
-      const error = json.error as
-        | {
-            type?: string;
-            title?: string;
-            detail?: string;
-            code?: string;
-            message?: string;
-            instance?: string;
-          }
-        | undefined;
-      const meta = json.meta as { request_id?: string; tombstone?: TombstoneInfo } | undefined;
-      throw new QURLAPIError(
-        response.status,
-        error?.code ?? "unknown",
-        error?.detail ?? error?.title ?? error?.message ?? `HTTP ${response.status}`,
-        error?.type,
-        error?.instance,
-        meta?.request_id,
-        meta?.tombstone,
-      );
-    }
-
-    return json as T;
+    return this._sdk;
   }
 
-  private parseJSON(text: string, status: number): Record<string, unknown> {
+  /** Run an SDK call, translating its errors into `QURLAPIError`. */
+  private async call<T>(fn: (sdk: SDKQURLClient) => Promise<T>): Promise<T> {
     try {
-      return JSON.parse(text) as Record<string, unknown>;
-    } catch {
-      throw new QURLAPIError(
-        status,
-        "parse_error",
-        `Failed to parse response: ${text.slice(0, 200)}`,
-      );
+      return await fn(this.sdk);
+    } catch (err) {
+      throw translateError(err);
     }
-  }
-
-  private qurlPath(id: string): string {
-    return `/v1/qurls/${encodeURIComponent(id)}`;
-  }
-
-  private resourcePath(id: string): string {
-    return `/v1/resources/${encodeURIComponent(id)}`;
-  }
-
-  private resourceQurlPath(resourceId: string, qurlId: string): string {
-    return `${this.resourcePath(resourceId)}/qurls/${encodeURIComponent(qurlId)}`;
   }
 
   async createQURL(input: CreateQURLInput): Promise<{ data: CreateQURLData }> {
-    return this.request("POST", "/v1/qurls", input);
+    return this.call(async (sdk) => ({
+      data: (await sdk.create(input as unknown as SDKCreateInput)) as unknown as CreateQURLData,
+    }));
   }
 
   async getQURL(id: string): Promise<{ data: QURL }> {
-    return this.request("GET", this.qurlPath(id));
+    return this.call(async (sdk) => ({ data: mapResource(await sdk.get(id)) }));
   }
 
   async listQURLs(input?: ListQURLsInput): Promise<ListQURLsOutput> {
-    const params = new URLSearchParams();
-    if (input?.limit !== undefined) params.set("limit", String(input.limit));
-    if (input?.cursor) params.set("cursor", input.cursor);
-    if (input?.status) params.set("status", input.status);
-    if (input?.created_after) params.set("created_after", input.created_after);
-    if (input?.created_before) params.set("created_before", input.created_before);
-    if (input?.expires_before) params.set("expires_before", input.expires_before);
-    if (input?.expires_after) params.set("expires_after", input.expires_after);
-    if (input?.sort) params.set("sort", input.sort);
-    if (input?.q) params.set("q", input.q);
-    const query = params.toString();
-    return this.request("GET", `/v1/qurls${query ? `?${query}` : ""}`);
+    return this.call(async (sdk) => {
+      const out = await sdk.list(input as unknown as SDKListInput);
+      return {
+        data: out.qurls.map(mapResource),
+        meta: { next_cursor: out.next_cursor, has_more: out.has_more },
+      };
+    });
   }
 
   async deleteQURL(id: string): Promise<void> {
-    await this.request("DELETE", this.qurlPath(id));
+    await this.call((sdk) => sdk.delete(id));
   }
 
   async updateQURL(id: string, input: UpdateQURLInput): Promise<{ data: QURL }> {
-    return this.request("PATCH", this.qurlPath(id), input);
+    return this.call(async (sdk) => ({
+      data: mapResource(await sdk.update(id, input as unknown as SDKUpdateInput)),
+    }));
   }
 
   async updateResource(id: string, input: UpdateResourceInput): Promise<{ data: QURL }> {
-    return this.request("PATCH", this.resourcePath(id), input);
+    return this.call(async (sdk) => ({
+      data: mapResource(await sdk.updateResource(id, input as unknown as SDKUpdateResourceInput)),
+    }));
   }
 
   async extendQURL(id: string, input: ExtendQURLInput): Promise<{ data: QURL }> {
-    // ExtendQURLInput is a strict subset of UpdateQURLInput (just extend_by),
-    // so we delegate to updateQURL rather than duplicating the PATCH call.
-    return this.updateQURL(id, input);
+    return this.call(async (sdk) => ({
+      data: mapResource(await sdk.extend(id, input as unknown as SDKExtendInput)),
+    }));
   }
 
   async resolveQURL(input: ResolveInput): Promise<{ data: ResolveOutput }> {
-    return this.request("POST", "/v1/resolve", input);
+    return this.call(async (sdk) => ({
+      data: (await sdk.resolve(input)) as unknown as ResolveOutput,
+    }));
   }
 
   async getQuota(): Promise<{ data: QuotaOutput }> {
-    return this.request("GET", "/v1/quota");
+    return this.call(async (sdk) => ({ data: (await sdk.getQuota()) as unknown as QuotaOutput }));
   }
 
   async mintLink(id: string, input?: MintLinkInput): Promise<{ data: MintLinkOutput }> {
-    return this.request("POST", `${this.qurlPath(id)}/mint_link`, input ?? {});
+    return this.call(async (sdk) => ({
+      data: (await sdk.mintLink(id, input as unknown as SDKMintInput)) as unknown as MintLinkOutput,
+    }));
   }
 
   async batchCreate(input: BatchCreateInput): Promise<BatchCreateOutput> {
-    // 400 carries per-item errors (see request() JSDoc).
-    return this.request("POST", "/v1/qurls/batch", input, [400]);
+    return this.call(async (sdk) => {
+      const out = await sdk.batchCreate(input as unknown as SDKBatchCreateInput);
+      return {
+        data: {
+          succeeded: out.succeeded,
+          failed: out.failed,
+          results: out.results as unknown as BatchItemResult[],
+        },
+        meta: { request_id: out.request_id },
+      };
+    });
   }
 
   async revokeQurlToken(resourceId: string, qurlId: string): Promise<void> {
-    await this.request("DELETE", this.resourceQurlPath(resourceId, qurlId));
+    await this.call((sdk) => sdk.revokeResourceQurl(resourceId, qurlId));
   }
 
   async updateQurlToken(
@@ -523,21 +541,36 @@ export class QURLClient implements IQURLClient {
     qurlId: string,
     input: UpdateQurlTokenInput,
   ): Promise<{ data: AccessToken }> {
-    return this.request("PATCH", this.resourceQurlPath(resourceId, qurlId), input);
+    return this.call(async (sdk) => ({
+      data: (await sdk.updateResourceQurl(
+        resourceId,
+        qurlId,
+        input as unknown as SDKUpdateResourceQurlInput,
+      )) as unknown as AccessToken,
+    }));
   }
 
   async listResourceSessions(resourceId: string): Promise<SessionListOutput> {
-    return this.request("GET", `${this.resourcePath(resourceId)}/sessions`);
+    return this.call(async (sdk) => {
+      const out = await sdk.listResourceSessions(resourceId);
+      return {
+        data: out.sessions as unknown as SessionData[],
+        meta: { request_id: out.request_id },
+      };
+    });
   }
 
   async terminateResourceSession(resourceId: string, sessionId: string): Promise<void> {
-    await this.request(
-      "DELETE",
-      `${this.resourcePath(resourceId)}/sessions/${encodeURIComponent(sessionId)}`,
-    );
+    await this.call((sdk) => sdk.terminateResourceSession(resourceId, sessionId));
   }
 
   async terminateAllResourceSessions(resourceId: string): Promise<SessionTerminateOutput> {
-    return this.request("DELETE", `${this.resourcePath(resourceId)}/sessions`);
+    return this.call(async (sdk) => {
+      const out = await sdk.terminateAllResourceSessions(resourceId);
+      return {
+        data: { terminated: out.terminated },
+        meta: { request_id: out.request_id },
+      };
+    });
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -432,7 +432,10 @@ export class QURLClient implements IQURLClient {
     // stray `QURL_API_KEY=" "`) takes the typed `missing_api_key` path
     // instead of being sent over the wire as a server-side 401.
     this.apiKey = (config.apiKey ?? "").trim();
-    this.baseURL = config.baseURL.replace(/\/$/, "");
+    // `?? ""` mirrors the apiKey guard above: a JS caller passing `undefined`
+    // for baseURL (the TS type forbids it; index.ts always supplies a default)
+    // gets the default-empty path rather than a raw TypeError from `.replace`.
+    this.baseURL = (config.baseURL ?? "").replace(/\/$/, "");
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,9 @@ const { version } = require("../package.json") as { version: string };
 
 // Auth validation is deferred to first API call so the server can boot for
 // MCP introspection (tools/list, resources/list, prompts/list) without a key.
-// Tool/resource invocations that hit the API will throw the same typed error
-// from `QURLClient.request()` if the key is missing.
+// Tool/resource invocations that hit the API will throw the same typed
+// `missing_api_key` error when the client lazily constructs the SDK on the
+// first call, if the key is still missing.
 //
 // Trim so whitespace-only values (e.g. `QURL_API_KEY=" "`) take the same
 // missing-key path as truly unset; otherwise they'd silently pass the guard


### PR DESCRIPTION
## What

Replaces the hand-rolled `src/client.ts` (its own `fetch`/retry/RFC-7807 parsing) with a thin **adapter over the published [`@layervai/qurl`](https://www.npmjs.com/package/@layervai/qurl) SDK**. This is the qurl-mcp half of the "use the layervai TypeScript client instead of rolling our own" migration — the SDK shipped to npm as `@layervai/qurl@0.2.0` (built from `layervai/qurl-typescript`).

The SDK now owns all transport: fetch, retries, error parsing, response shape validation. `client.ts` keeps the exact same public surface — every domain type, the `IQURLClient` interface, `QURLAPIError`, and `MISSING_API_KEY_MESSAGE` are unchanged — and only **translates** between the SDK and that contract:

| Concern | Translation |
|---|---|
| Return envelopes | Re-wrap the SDK's unwrapped returns in `{ data }` |
| Field name | Rename the SDK's `access_tokens` → `qurls` |
| List / batch / sessions | Reshape `{qurls,next_cursor,has_more}`, flatten `BatchCreateOutput`, map `{sessions}`→`{data}` and `{terminated}`→`{data:{terminated}}` |
| Method names | `revokeQurlToken`→`revokeResourceQurl`, `updateQurlToken`→`updateResourceQurl` |
| Errors | `QURLError` subclasses → `QURLAPIError`, preserving `statusCode`/`code`/`requestId` (delete-qurl branches on `statusCode === 404`) |
| Keyless boot | SDK built **lazily** on first call (its constructor throws on an empty key); `index.ts` still boots keyless for MCP introspection, and the missing-key path still emits `MISSING_API_KEY_MESSAGE` |

## Why it's low-risk

The `IQURLClient` interface and all output shapes are identical, so the **24 tool/resource/output-schema test files pass untouched** — direct evidence the MCP's external contract (tool I/O, `qurls`, `{data}` wrapping) is preserved. Only `client.test.ts` is rewritten: it previously tested the hand-rolled HTTP layer (now the SDK's job) and now covers the adapter's translation logic (keyless boot, `{data}` wrapping, `access_tokens`→`qurls`, envelope reshaping, method renames, `QURLError`→`QURLAPIError`).

## Verification (local)

- `npm run build` ✅ · `npm run lint` ✅ · `npm run format:check` ✅
- `npm test` ✅ — **421 passed (25 files)**
- `npm ci` ✅ — resolves `@layervai/qurl@0.2.0` from the lockfile (the repo's `min-release-age=7` gate applies to `npm install` resolution, not `npm ci`, so CI is unaffected even though the SDK was just published)

## Notes / follow-ups

- **Minor parity gap:** the SDK's `QURLError` does not surface `tombstone` (410 path), so `QURLAPIError.tombstone` is now always `undefined`. No MCP tool reads it, so there's no functional impact — flagging for an optional future SDK enhancement.
- A local `npm install` of `@layervai/qurl` is age-gated until ~2026-06-20 (the 7-day supply-chain window); use `--min-release-age=0` for local lockfile regen until then. CI (`npm ci`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)