### PR TITLE
ci: publish @layervai/qurl-mcp via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,15 +42,27 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
+          # Required for OIDC trusted publishing — npm runs the OIDC exchange
+          # against this registry. setup-node also injects a placeholder
+          # NODE_AUTH_TOKEN, but npm's OIDC auth takes precedence once the
+          # trusted publisher matches (verified on @layervai/qurl).
           registry-url: "https://registry.npmjs.org"
+      # Trusted publishing requires npm >= 11.5.1; Node 22 still bundles npm
+      # 10.x, so pin a known-good CLI (old enough to clear .npmrc's
+      # min-release-age gate) before publishing.
+      - name: Pin npm for trusted publishing
+        run: npm install -g npm@11.10.0
       - name: Install dependencies
         run: npm ci
       - name: Build
         run: npm run build
+      # Trusted publishing (OIDC): no NODE_AUTH_TOKEN. With the job's
+      # `id-token: write`, npm authenticates via the trusted publisher
+      # configured for @layervai/qurl-mcp on npmjs.com (provider GitHub
+      # Actions, repo layervai/qurl-mcp, workflow release-please.yml,
+      # environment npm-publish). Matches the @layervai/qurl SDK's setup.
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-mcp-registry:
     # See CLAUDE.md §"MCP Registry" for the why (GITHUB_TOKEN cross-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,9 +47,10 @@ jobs:
           # NODE_AUTH_TOKEN, but npm's OIDC auth takes precedence once the
           # trusted publisher matches (verified on @layervai/qurl).
           registry-url: "https://registry.npmjs.org"
-      # Trusted publishing requires npm >= 11.5.1; Node 22 still bundles npm
-      # 10.x, so pin a known-good CLI (old enough to clear .npmrc's
-      # min-release-age gate) before publishing.
+      # Trusted publishing needs npm >= 11.5.1; Node 22 bundles npm 10.x. This
+      # install runs under that bundled npm 10.x, which ignores .npmrc's
+      # `min-release-age` gate, so the pin always resolves. Keep the version in
+      # sync with the @layervai/qurl SDK's pinned npm.
       - name: Pin npm for trusted publishing
         run: npm install -g npm@11.10.0
       - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,13 @@ The repository includes an API spec drift detection system:
 - **Action:** When an issue is opened, review the diff, update `api-spec/qurls.yaml`, update client types/tools as needed, and verify with `npm run build && npm run lint && npm test`.
 - **Spec URL:** Configurable via the `QURL_API_SPEC_URL` repository variable. Defaults to `https://api.layerv.ai/v1/openapi.yaml`.
 
+## npm Publishing (Trusted Publishing / OIDC)
+
+- The `publish` job in `.github/workflows/release-please.yml` publishes to npm via **OIDC trusted publishing — there is no `NODE_AUTH_TOKEN`/`NPM_TOKEN`.** Do **not** re-add a token when debugging a publish failure; npm authenticates via the trusted publisher using the job's `id-token: write`.
+- **npmjs.com prerequisite:** a trusted publisher must be configured for `@layervai/qurl-mcp` (provider GitHub Actions, repo `layervai/qurl-mcp`, workflow `release-please.yml`, environment `npm-publish`). A mismatch (or a missing config) surfaces only at publish time on a tagged release, as `E404`/`ENEEDAUTH` — there is no token fallback.
+- The job pins `npm@11.10.0` before publishing because trusted publishing needs npm ≥ 11.5.1 and Node 22 bundles npm 10.x. Keep this in sync with the `@layervai/qurl` SDK's pinned npm.
+- This mirrors the SDK repo (`layervai/qurl-typescript`), which uses the same trusted-publishing setup.
+
 ## MCP Registry
 
 - **Manifest:** `server.json` (validated against the registry's JSON Schema). Both `$.version` and `$.packages[0].version` are kept in sync with `package.json` automatically by release-please's `extra-files` config.


### PR DESCRIPTION
## What

Aligns the MCP's npm publish with the `@layervai/qurl` SDK: switches from a `NODE_AUTH_TOKEN` secret to **OIDC trusted publishing**.

The publish job was already 90% there (`environment: npm-publish`, `id-token: write`, `registry-url`, `npm publish --provenance --access public`). This PR:
- **Removes** the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env from the publish step → npm authenticates via OIDC against the trusted publisher.
- **Pins `npm@11.10.0`** before publish — trusted publishing requires npm ≥ 11.5.1, and Node 22 still bundles npm 10.x. (Same version the SDK uses; old enough to clear the repo's `min-release-age` gate.)

This is the exact setup just **validated** on `@layervai/qurl` (a manual publish there authenticated via OIDC and only failed on "cannot publish over existing version").

## ⚠️ Required before the next release

A **trusted publisher must be configured for `@layervai/qurl-mcp`** on npmjs.com, or the next release's publish will fail auth (the same trap the SDK hit when its trusted publisher was on the wrong package):

- Provider: **GitHub Actions**
- Organization: **layervai** · Repository: **qurl-mcp**
- Workflow filename: **release-please.yml**
- Environment: **npm-publish**

`@layervai/qurl-mcp` already exists on npm (0.4.0), so this is added under the package's **Settings → Trusted Publishers**. Once this lands and a release publishes successfully, the `NPM_TOKEN` repo secret can be removed.

## Note
Only the **npm** publish moves to OIDC. The separate `publish-mcp-registry` job (MCP registry via `mcp-publisher`) already uses OIDC and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)