### PR TITLE
ci: bump mcp-publisher to v1.7.9 to fix MCP registry OIDC audience

### DIFF
--- a/.github/actions/publish-mcp-registry/action.yml
+++ b/.github/actions/publish-mcp-registry/action.yml
@@ -21,11 +21,16 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        version="v1.7.2"
+        # mcp-publisher >= v1.7.6 is REQUIRED: the registry binds the GitHub
+        # OIDC token exchange to a per-deployment audience
+        # (https://registry.modelcontextprotocol.io). Older publishers request
+        # the legacy `mcp-registry` audience and fail `login github-oidc` with
+        # a 401 "invalid audience". Do not downgrade below v1.7.6.
+        version="v1.7.9"
         tarball="mcp-publisher_linux_amd64.tar.gz"
-        # Pinned sha256 from upstream registry_1.7.2_checksums.txt — bump
+        # Pinned sha256 from upstream registry_1.7.9_checksums.txt — bump
         # alongside the `version` above when upgrading the publisher.
-        expected_sha="9a324bab0bc69bf957599d7975b663d7c4169eba2cdc00baf0f589b847e03898"
+        expected_sha="ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"
         url="https://github.com/modelcontextprotocol/registry/releases/download/${version}/${tarball}"
         curl -fsSL --retry 3 --retry-delay 5 "$url" -o /tmp/mcp-publisher.tar.gz
         echo "${expected_sha}  /tmp/mcp-publisher.tar.gz" | sha256sum -c -


### PR DESCRIPTION
## What

Bumps the pinned `mcp-publisher` in `.github/actions/publish-mcp-registry/action.yml` from **v1.7.2 → v1.7.9** (and its sha256), and documents the v1.7.6 floor.

## Why

The `publish-mcp-registry` job **failed on the 0.4.1 release** ([run 27479358558](https://github.com/layervai/qurl-mcp/actions/runs/27479358558)) at `mcp-publisher login github-oidc`:

```
token exchange failed with status 401: failed to validate OIDC token:
invalid audience: expected https://registry.modelcontextprotocol.io, got [mcp-registry]
```

The MCP registry started **binding the GitHub OIDC token exchange to a per-deployment audience** in registry [v1.7.6](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.6) (PR #1229). The pinned **v1.7.2** publisher still requests the legacy `mcp-registry` audience, so login is rejected with a 401.

> **Scope:** npm **trusted publishing succeeded** — `@layervai/qurl-mcp@0.4.1` is live on npm. This only fixes the *separate* step that advertises the version to the MCP registry (which is still stale at 0.3.4).

## Verification

- ✅ Downloaded `mcp-publisher_linux_amd64.tar.gz` for v1.7.9; sha256 matches the upstream `registry_1.7.9_checksums.txt` (`ab128162…81ac`).
- ✅ The v1.7.9 binary embeds `https://registry.modelcontextprotocol.io` (the new audience) and the `&audience=` OIDC-request logic.
- ✅ Namespace auth is known-good: `io.github.layervai/qurl-mcp` already lists **0.3.4** in the registry (it published fine before the registry deployed the audience binding), so the audience mismatch is the sole break.
- ✅ Bare `login github-oidc` + `publish` invocations are unchanged in v1.7.9 (only docs/flag alignment landed in 1.7.7–1.7.9; no breaking changes).

## After merge

Manually dispatch `publish-mcp-registry.yml` (workflow_dispatch) to advertise **0.4.1** to the registry — this also corrects the stale pre-rename npm id (registry currently shows `@layerv/qurl-mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)