### PR TITLE
ci: use shared notify.yml reusable for the Slack build card

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,110 +174,20 @@ jobs:
             -f description="lint=$LINT_RESULT test=$TEST_RESULT docker=$DOCKER_RESULT" \
             -f target_url="$TARGET_URL"
 
+  # Slack build-completion card. Thin shim over the fleet-shared reusable
+  # in layervai/ops-routines-workflows (public mirror of private
+  # layervai/ops-routines); the curl/jq Block Kit payload builder and the
+  # gate-result aggregation live there now. Adding/removing a gate is a
+  # one-line edit to `needs:` + `gates:` here — no aggregation if-chain.
+  # NOTE: the separate `ci/aggregate` commit-status job above is unrelated.
   notify:
     name: Notify
     needs: [lint, test, docker]
     if: always() && github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    continue-on-error: true
-    steps:
-      - name: Notify Slack
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-          TEST_RESULT: ${{ needs.test.result }}
-          LINT_RESULT: ${{ needs.lint.result }}
-          DOCKER_RESULT: ${{ needs.docker.result }}
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          GH_SERVER_URL: ${{ github.server_url }}
-          GH_REPOSITORY: ${{ github.repository }}
-          GH_RUN_ID: ${{ github.run_id }}
-          GH_SHA: ${{ github.sha }}
-          GH_REF_NAME: ${{ github.ref_name }}
-          GH_ACTOR: ${{ github.actor }}
-          GH_EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [[ -z "$SLACK_WEBHOOK" ]]; then
-            echo "SLACK_WEBHOOK_URL not configured, skipping notification"
-            exit 0
-          fi
-
-          WORKFLOW_URL="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
-          SHORT_SHA="${GH_SHA:0:7}"
-          COMMIT_URL="${GH_SERVER_URL}/${GH_REPOSITORY}/commit/${GH_SHA}"
-
-          case "$GH_EVENT_NAME" in
-            push)
-              if echo "$COMMIT_MESSAGE" | head -n1 | grep -q "Merge pull request"; then
-                TRIGGER_TEXT="PR merge"
-              else
-                TRIGGER_TEXT="Push"
-              fi
-              ;;
-            *) TRIGGER_TEXT="$GH_EVENT_NAME" ;;
-          esac
-
-          # Overall status: fail if any of lint, test, docker failed
-          HEADER="qURL MCP Build"
-          if [[ "$TEST_RESULT" == "success" && "$LINT_RESULT" == "success" && "$DOCKER_RESULT" == "success" ]]; then
-            COLOR="#36a64f"; EMOJI=":white_check_mark:"; STATUS_TEXT="successful"
-          elif [[ "$TEST_RESULT" == "failure" || "$LINT_RESULT" == "failure" || "$DOCKER_RESULT" == "failure" ]]; then
-            COLOR="#dc3545"; EMOJI=":x:"; STATUS_TEXT="failed"
-          elif [[ "$TEST_RESULT" == "cancelled" || "$LINT_RESULT" == "cancelled" || "$DOCKER_RESULT" == "cancelled" ]]; then
-            COLOR="#ffc107"; EMOJI=":warning:"; STATUS_TEXT="cancelled"
-          else
-            COLOR="#ffc107"; EMOJI=":warning:"; STATUS_TEXT="incomplete"
-          fi
-
-          case "$TEST_RESULT" in
-            success) TEST_EMOJI=":white_check_mark:" ;;
-            failure) TEST_EMOJI=":x:" ;;
-            *) TEST_EMOJI=":warning:" ;;
-          esac
-          case "$LINT_RESULT" in
-            success) LINT_EMOJI=":white_check_mark:" ;;
-            failure) LINT_EMOJI=":x:" ;;
-            *) LINT_EMOJI=":warning:" ;;
-          esac
-          case "$DOCKER_RESULT" in
-            success) DOCKER_EMOJI=":white_check_mark:" ;;
-            failure) DOCKER_EMOJI=":x:" ;;
-            *) DOCKER_EMOJI=":warning:" ;;
-          esac
-
-          FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n1 | cut -c1-100)
-          FIRST_LINE="${FIRST_LINE:-(no commit message)}"
-
-          PAYLOAD=$(jq -n \
-            --arg color "$COLOR" \
-            --arg emoji "$EMOJI" \
-            --arg header "$HEADER" \
-            --arg status "$STATUS_TEXT" \
-            --arg branch "$GH_REF_NAME" \
-            --arg sha "$SHORT_SHA" \
-            --arg trigger "$TRIGGER_TEXT" \
-            --arg actor "$GH_ACTOR" \
-            --arg test_emoji "$TEST_EMOJI" \
-            --arg lint_emoji "$LINT_EMOJI" \
-            --arg docker_emoji "$DOCKER_EMOJI" \
-            --arg commit "$FIRST_LINE" \
-            --arg commit_url "$COMMIT_URL" \
-            --arg workflow_url "$WORKFLOW_URL" \
-            '{attachments: [{color: $color, blocks: [
-              {type: "section", text: {type: "mrkdwn", text: ("\($emoji) *\($header)* \($status)")}},
-              {type: "section", fields: [
-                {type: "mrkdwn", text: ("*Branch:*\n`\($branch)` (\($sha))")},
-                {type: "mrkdwn", text: ("*Trigger:*\n\($trigger) by \($actor)")},
-                {type: "mrkdwn", text: ("*Lint:*\n\($lint_emoji)")},
-                {type: "mrkdwn", text: ("*Tests:*\n\($test_emoji)")},
-                {type: "mrkdwn", text: ("*Docker:*\n\($docker_emoji)")}
-              ]},
-              {type: "section", text: {type: "mrkdwn", text: ("*Commit:* `\($commit)`")}},
-              {type: "context", elements: [
-                {type: "mrkdwn", text: ("<\($commit_url)|\($sha)>  |  <\($workflow_url)|View workflow>")}
-              ]}
-            ]}]}')
-
-          curl -sfS -X POST "$SLACK_WEBHOOK" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" || echo "Slack notification failed (non-critical)"
+    permissions: {}
+    uses: layervai/ops-routines-workflows/.github/workflows/notify.yml@1536c698add5777aa08c781bc674d1eba469b32d # v0.9.0
+    with:
+      header: "qURL MCP Build"
+      gates: '{"Lint": "${{ needs.lint.result }}", "Tests": "${{ needs.test.result }}", "Docker": "${{ needs.docker.result }}"}'
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## What

Converts this repo's inline ~100-line Slack build-notification job into a thin shim over the fleet-shared reusable [`layervai/ops-routines-workflows/.github/workflows/notify.yml@v0.9.0`](https://github.com/layervai/ops-routines-workflows/releases/tag/v0.9.0), mirroring how the `issue-priority` shim was centralized.

- Header preserved: **qURL MCP Build**
- Gates: `{"Lint": "...", "Tests": "...", "Docker": "..."}`
- Run condition (`if:` / `needs:`) unchanged from the inline job.
- The curl/jq Block Kit payload builder and the gate-result aggregation that were duplicated here (3×: `needs:`, per-gate `env:`, aggregation if-chain) now live once in the reusable. Adding a gate is a one-line edit to `needs:` + `gates:`.

## Notes

- Pinned by SHA (`@1536c69 # v0.9.0`), matching the fleet's reusable-ref convention.
- The `notify` job runs only on push (`if: … github.event_name != 'pull_request'`), so it is skipped on this PR — no behavior change to required PR checks.
- `SLACK_WEBHOOK_URL` is passed through as an optional secret; absent ⇒ the reusable no-ops.

Source reusable PR: layervai/ops-routines#80.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>