### PR TITLE
ci: set Claude interactive workflow to Opus 4.8

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb # v1
+        uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb # v1.0.153
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: '--model claude-opus-4-8'


### PR DESCRIPTION
Fleet-wide consistency pass for the Claude Code GitHub Action config.

The `anthropics/claude-code-action` pin is already current (`2fee155…`, v1.0.153), so this only:

- Adds `claude_args: '--model claude-opus-4-8'` to the interactive `claude.yml` so `@claude` mentions run on Opus 4.8.
- Normalizes the pin comment from `# v1` to the explicit `# v1.0.153` tag for clarity.

`claude-code-review.yml` is already correct and is left untouched.