### PR TITLE
ci: skip Claude code review job on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,7 +6,13 @@ on:
 
 jobs:
   review:
-    if: github.actor != 'dependabot[bot]'
+    # Fork PRs get neither secrets nor OIDC (ANTHROPIC_API_KEY is empty and
+    # the id-token permission is never granted), so the action cannot run
+    # there. Do NOT "fix" by switching to pull_request_target — that would
+    # expose secrets to untrusted fork code.
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

The `Claude Code Review` workflow fails on every PR opened from a fork — seen on #182:

```
Failed to get OIDC token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Attempt 3 failed: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

The workflow already declares `id-token: write`; the problem is that GitHub never grants OIDC (nor repository secrets — `ANTHROPIC_API_KEY` was empty in the job env) to `pull_request` runs triggered from forks. The job can never succeed for fork PRs as configured.

## Fix

Skip the `review` job when the PR head repo isn't this repo, alongside the existing dependabot guard. This is the approach recommended by the claude-code-action docs. Deliberately **not** switching to `pull_request_target`, which would run with secrets against untrusted fork code (API-key exfiltration risk); a comment in the workflow warns against that.

Notes:
- `review` is not a required status check, so skipping doesn't block fork PR merges.
- `claude.yml` needs no change: comment-triggered events always run in base-repo context.
- Fork PRs simply won't get an automated Claude review; maintainers can still request one by commenting `@claude`.

## Test plan

- [x] `actionlint` clean on the edited workflow
- [x] `npm run build && npm run lint && npm test` (429 tests pass)
- [ ] Verify the job shows as *skipped* (not failed) on the next fork PR sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)