### PR TITLE
ci: add manual dispatch to review fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,16 +3,30 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+  # Maintainer-triggered review for fork PRs, which the pull_request
+  # trigger skips (no secrets/OIDC there). This mode never checks out the
+  # PR's code — Claude reads the diff via `gh pr diff` — so it is safe to
+  # run against untrusted forks. It also sidesteps
+  # anthropics/claude-code-action#1423, which breaks @claude tag-mode on
+  # fork PRs whose head branch is named "main".
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: string
 
 jobs:
   review:
     # Fork PRs get neither secrets nor OIDC (ANTHROPIC_API_KEY is empty and
     # the id-token permission is never granted), so the action cannot run
     # there. Do NOT "fix" by switching to pull_request_target — that would
-    # expose secrets to untrusted fork code.
+    # expose secrets to untrusted fork code. To review a fork PR, use the
+    # workflow_dispatch trigger above.
     if: |
-      github.actor != 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'workflow_dispatch' ||
+      (github.actor != 'dependabot[bot]' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -33,7 +47,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
 
             Review this PR following the guidance in CLAUDE.md.
             Focus on:


### PR DESCRIPTION
## Summary

Follow-up to #184. That PR made the `review` job correctly skip fork PRs (where secrets/OIDC don't exist), but left no way to run a Claude review on one. The `@claude` comment fallback turned out to be broken for #182 specifically: the contributor opened it from their fork's `main` branch, and tag mode crashes trying `git fetch origin pull/182/head:main` into the checked-out base `main` — upstream bug [anthropics/claude-code-action#1423](https://github.com/anthropics/claude-code-action/issues/1423), still open as of v1.0.165 ([failed run](https://github.com/layervai/qurl-mcp/actions/runs/28826972016)).

## Fix

Add a `workflow_dispatch` trigger with a `pr_number` input to the existing review workflow. The prompt resolves the PR number from either event: `${{ github.event.pull_request.number || inputs.pr_number }}`.

Why this is safe for untrusted forks:
- Dispatch runs in base-repo context; checkout is `main`, **never the fork's code**. Claude reads the diff as data via `gh pr diff`.
- Same restricted `--allowed-tools` as the automatic review (read-only `gh` commands + `gh pr comment`) — no arbitrary Bash, no code execution.
- Requires a maintainer to dispatch (write access), so it's a deliberate per-PR decision.

## Usage

```bash
gh workflow run claude-code-review.yml -f pr_number=182
```

## Test plan

- [x] actionlint clean
- [x] `npm run build && npm run lint && npm test` (429 tests pass)
- [ ] After merge: dispatch for PR #182 and confirm the review comment lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)