### PR TITLE
docs(resources): rename connector-disabled error

### DIFF
--- a/api-spec/qurls.yaml
+++ b/api-spec/qurls.yaml
@@ -1258,8 +1258,8 @@ paths:
           - 404 `resource_not_found` if no resource with this ID exists.
           - 403 `access_denied` if the resource exists but belongs to
             another owner.
-          - 403 `tunnel_disabled` if the resource is a tunnel and
-            tunnel minting is currently unavailable.
+          - 403 `connector_disabled` if this is a qURL Connector resource
+            (`type: tunnel` on the wire) and minting is currently unavailable.
           - 400 `revoked` if the resource is revoked.
           - 400 `invalid_input` for malformed or out-of-range field
             values (e.g. a `session_duration` like `5x`).


### PR DESCRIPTION
## Summary

Updates the vendored qurl-service OpenAPI snapshot for the greenfield public error-code rename from `tunnel_disabled` to `connector_disabled`, using qURL Connector terminology in the human-facing description.

Business relevance: MCP documentation must describe the exact producer contract so developers do not build against a retired error code.

## Changes

- Rename the documented 403 code to `connector_disabled`.
- Describe the affected resource as a qURL Connector resource.

## Test Plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (782 tests)
- [x] YAML parses successfully
- [x] `git diff --check`
- [ ] Manually tested with MCP client (not applicable; docs snapshot only)

## Coordination

This PR remains draft and must merge in lockstep with the companion qurl-service producer change. The retired error code is intentionally not documented as an alias.

- Companion producer PR: layervai/qurl-service#1211
- Producer hotfix/post-merge proof tracker: layervai/qurl-service#1222
- Cross-repository delivery tracker: layervai/qurl-connector#421

No failing check or merge conflict currently exists on this draft; the deferral is dependency ordering.

## Related Issues

Tracked by layervai/qurl-connector#421.
